### PR TITLE
Add basic Cirrus CI build file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,19 @@
+build_web_task:
+  container:
+    image: node:latest
+  node_modules_cache:
+    folder: node_modules
+    fingerprint_script: cat web/package-lock.json
+    populate_script: make ci-setup-web
+  build_script: make build-web
+
+build_api_task:
+  container:
+    image: golang:latest
+  env:
+    GOPROXY: https://proxy.golang.org
+  modules_cache:
+    fingerprint_script: cat go.sum
+    folder: $GOPATH/pkg/mod
+  build_script: make build-api
+  test_script: make test-api

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,7 @@ task:
   build_script: make build-web
 
 build_api_task:
+  name: Build Api
   container:
     image: golang:latest
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ task:
     populate_script: make ci-setup-web
   build_script: make build-web
 
-build_api_task:
+task:
   name: Build Api
   container:
     image: golang:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,6 @@
-build_web_task:
+task:
+  name: Build Web
+  skip: "!changesInclude('.cirrus.yml', 'web/**')"
   container:
     image: node:latest
   node_modules_cache:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ clean:
 setup-web: web/package.json web/package-lock.json
 	npm install --prefix $(WEB_FOLDER)
 
+ci-setup-web: web/package.json web/package-lock.json
+	npm ci --prefix $(WEB_FOLDER)
+
 build-web:
 	npm run build:dist --prefix $(WEB_FOLDER)
 
@@ -19,6 +22,9 @@ run-web:
 	npm start --prefix $(WEB_FOLDER)
 
 run: build-web run-api
+
+build-api:
+	GO111MODULE=on go build ./...
 
 test-api:
 	GO111MODULE=on go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Periskop
 
+[![Build Status](https://api.cirrus-ci.com/github/soundcloud/periskop.svg)](https://cirrus-ci.com/github/soundcloud/periskop)
+
 Pull based, language agnostic exception aggregator for microservice environments.
 
 Periskop scales well with the number of exceptions and application instances:


### PR DESCRIPTION
This PR adds a basic Cirrus CI file that builds the web component and build and test the api one.
Marking as WIP until we have Cirrus CI enabled for the project.