### PR TITLE
Allow CORS requests only for local development

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,7 +12,11 @@ import (
 
 func NewHandler(r repository.ErrorsRepository) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", req.Header.Get("Origin"))
+		// Allow CORS requests for local development since API and frontend run on different ports
+		origin := req.Header.Get("Origin")
+		if strings.HasPrefix(origin, "http://localhost:") {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
 
 		path := strings.TrimPrefix(req.URL.Path, "/services/")
 		numberOfOccurrencesPerError := 10


### PR DESCRIPTION
Allowing CORS requests for all origins is very dangerous. We previously
added this for local development only, where the API and frontend server
run on different ports. Therefore a CORS policy was needed.

We now only add the CORS headers for this specific scenario, thus
blocking CORS requests for all non-local access.