### PR TITLE
Show request headers

### DIFF
--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -102,7 +102,7 @@ const ErrorComponent =  (props: Props) => {
     if (context.request_headers == null) {
       return ''
     } else {
-      Object.keys(context.request_headers).map(function(key) {
+      return Object.keys(context.request_headers).map(function(key) {
         return renderContextHeadersRow(key, context.request_headers[key])
       })
     }


### PR DESCRIPTION
  - Requests headers were not properly shown due to a missing return
  statement.
  - Fixes https://github.com/soundcloud/periskop/issues/19
