### PR TITLE
Fix CSS scrolling issues

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Jorge Creixell <jorge.creixell@soundcloud.com>
 Michael Smith <michael.smith@soundcloud.com>
 Riccardo Ciovati <riccardo.ciovati@soundcloud.com>
 Marc Tuduri <marctc@gmail.com>
+Can Göktas <can.goektas@soundcloud.com>

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -53,7 +53,7 @@ class App extends React.Component<Props> {
     if (RemoteData.isSuccess(this.props.errors)) {
       let activeError = this.props.errors.data.find(e => e.aggregation_key === this.props.match.params.errorKey)
       if (
-        activeError != undefined &&
+        activeError !== undefined &&
         (this.props.activeError !== this.props.match.params.errorKey) &&
         !RemoteData.isLoading(this.props.errors)) {
           this.props.setActiveError(activeError.aggregation_key)

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -89,9 +89,9 @@ class App extends React.Component<Props> {
 
   render() {
     return (
-      <div>
-          <Grid fluid>
-            <Row className="show-grid">
+      <div className="app-component">
+          <Grid fluid className="app-component-grid">
+            <Row className="app-component-row">
               <Col xs={3} id="left-column">
                 {this.renderSideBar()}
               </Col>

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -28,7 +28,7 @@ const ErrorComponent =  (props: Props) => {
   }
 
   const renderStackTrace = (stackTrace: string[]) => {
-    if (stackTrace == null || stackTrace.length == 0) {
+    if (stackTrace === null || stackTrace.length === 0) {
       return ""
     }
     const trace =  stackTrace.map((line) => line + "\n")
@@ -45,7 +45,7 @@ const ErrorComponent =  (props: Props) => {
   }
 
   const renderCause = (cause: Error) => {
-    if (cause == null) {
+    if (cause === null) {
       return ""
     }
 
@@ -58,7 +58,7 @@ const ErrorComponent =  (props: Props) => {
   }
 
   const renderMessage = (message: string) => {
-    if (message == null || message.trim().length == 0) {
+    if (message === null || message.trim().length === 0) {
       return ""
     }
 
@@ -91,7 +91,7 @@ const ErrorComponent =  (props: Props) => {
 
   const renderContextHeadersRow = (key: string, value: string) => {
     return (
-      <tr>
+      <tr key={key}>
         <td>{`${key}`}</td>
         <td>{`${value}`}</td>
       </tr>
@@ -100,7 +100,7 @@ const ErrorComponent =  (props: Props) => {
 
   const renderContextHeaders = (context: HttpContext) => {
     if (context.request_headers == null) {
-      return ''
+      return ""
     } else {
       return Object.keys(context.request_headers).map(function(key) {
         return renderContextHeadersRow(key, context.request_headers[key])

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -74,21 +74,29 @@ class NavbarComponent extends React.Component<Props, {}> {
 
   render() {
     return (
-      <Navbar fluid inverse collapseOnSelect staticTop>
+        <Navbar
+          fluid
+          inverse
+          collapseOnSelect
+          fixedTop
+        >
         <Navbar.Header>
           <Navbar.Brand>
             <a href="/">Periskop</a>
           </Navbar.Brand>
+          <Navbar.Toggle/>
         </Navbar.Header>
-        <Nav>
-          <NavDropdown title={this.props.activeService ? this.props.activeService : "Service"} id="project-nav-dropdown">
-          {this.renderServicesInDropdown()}
-          </NavDropdown>
-        </Nav>
-        <Nav pullRight>
-          {this.renderRefreshButton()}
-        </Nav>
-        <Navbar.Text pullRight>{this.renderUpdatedAt()}</Navbar.Text>
+        <Navbar.Collapse>
+          <Nav>
+            <NavDropdown title={this.props.activeService ? this.props.activeService : "Service"} id="project-nav-dropdown">
+            {this.renderServicesInDropdown()}
+            </NavDropdown>
+          </Nav>
+          <Nav pullRight>
+            {this.renderRefreshButton()}
+          </Nav>
+          <Navbar.Text pullRight>{this.renderUpdatedAt()}</Navbar.Text>
+        </Navbar.Collapse>
       </Navbar>
     )
   }

--- a/web/src/data/errors.ts
+++ b/web/src/data/errors.ts
@@ -77,7 +77,7 @@ function errorsReducer(state = initialState, action: ErrorsAction) {
         case RemoteData.SUCCESS:
           return {
             ...state,
-            activeError: state.errors.data.find(e => e.aggregation_key == action.errorKey)
+            activeError: state.errors.data.find(e => e.aggregation_key === action.errorKey)
           }
         default: {
           return state

--- a/web/src/index.less
+++ b/web/src/index.less
@@ -27,8 +27,7 @@
     line-height: 18px;
 
     width: 100%;
-    height: 100%;
-    margin-bottom: 60px;
+    height: 100vh;
 }
 
 p, ol, ul, td {
@@ -43,27 +42,28 @@ pre {
     max-height: 400px;
 }
 
+#app,
+.app-container,
+.app-container > div,
+.app-content,
+.app-component,
+.app-component-grid,
+.app-component-row {
+  height: 100%;
+}
+
+.app-container {
+  padding-top: @navbar-height + @navbar-margin-bottom;
+}
+
 #left-column {
+  height: calc(100% - @navbar-margin-bottom);
   overflow-y: scroll;
-  height: 100vh;
 }
 
 #right-column {
+  height: 100%;
   overflow-y: scroll;
-  height: 100vh;
-}
-
-::-webkit-scrollbar {
-  width: 0px;
-  background: transparent;
-}
-
-* {
-  -ms-overflow-style: none !important;
-}
-
-.grid-component {
-  margin-bottom: 100px;
 }
 
 td {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -18,11 +18,13 @@ const history = createHashHistory()
 render(
     <Provider store={store}>
         <Router history={history}>
-            <div>
+            <div className="app-container">
                 <NavbarComponent />
-                <Route exact path="/" component={Home}/>
-                <Route exact path="/:service" component={App}/>
-                <Route path="/:service/errors/:errorKey" component={App}/>
+                <main className="app-content">
+                    <Route exact path="/" component={Home}/>
+                    <Route exact path="/:service" component={App}/>
+                    <Route path="/:service/errors/:errorKey" component={App}/>
+                </main>
             </div>
         </Router>
     </Provider>,


### PR DESCRIPTION
### Changes

- Fixes a couple of TSLint warnings
- Tweaks the CSS for the navbar and the sidebar, so that the navbar is always visible and the height of the sidebar doesn't exceed the viewport height

### Notes

- I think later on we should introduce a `Sidebar` component and get rid of all the `height: 100%` declarations. It feels a bit hacky right now but I think that's also because Bootstrap doesn't have what we need. Maybe we should get rid of it?
- The `@navbar-height` and `@navbar-margin-bottom` are Bootstrap LESS variables