### PR TITLE
Add support for severity levels

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -104,9 +104,11 @@ func TestErrorsForKnownServiceReturnsErrors(t *testing.T) {
 	r.StoreErrors("api-test", []repository.ErrorAggregate{
 		{
 			AggregationKey: "key",
+			Severity:       "error",
 			LatestErrors: []repository.ErrorWithContext{
 				{
 					Error:     repository.ErrorInstance{},
+					Severity:  "error",
 					Timestamp: time.Unix(0, 0).Unix(),
 				},
 			},
@@ -119,7 +121,7 @@ func TestErrorsForKnownServiceReturnsErrors(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	// nolint
-	expected := `[{"aggregation_key":"key","total_count":0,"latest_errors":[{"error":{"class":"","message":"","stacktrace":null,"cause":null},"uuid":"","timestamp":0,"http_context":{"request_method":"","request_url":"","request_headers":null}}]}]` + "\n"
+	expected := `[{"aggregation_key":"key","total_count":0,"severity":"error","latest_errors":[{"error":{"class":"","message":"","stacktrace":null,"cause":null},"uuid":"","timestamp":0,"severity":"error","http_context":{"request_method":"","request_url":"","request_headers":null}}]}]` + "\n"
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -7,6 +7,7 @@ import (
 type ErrorAggregate struct {
 	AggregationKey string             `json:"aggregation_key"`
 	TotalCount     int                `json:"total_count"`
+	Severity       string             `json:"severity"`
 	LatestErrors   []ErrorWithContext `json:"latest_errors"`
 }
 
@@ -14,6 +15,7 @@ type ErrorWithContext struct {
 	Error       ErrorInstance `json:"error"`
 	UUID        string        `json:"uuid"`
 	Timestamp   int64         `json:"timestamp"`
+	Severity    string        `json:"severity"`
 	HTTPContext HTTPContext   `json:"http_context"`
 }
 

--- a/representation/errors.proto
+++ b/representation/errors.proto
@@ -8,14 +8,16 @@ message Errors {
 message AggregatedError {
     string aggregationKey = 1;
     int64 totalCount = 2;
-    repeated ErrorInstance latestErrors = 3; // A list of the last N error instances
+    string severity = 3; // Either info, warning or error
+    repeated ErrorInstance latestErrors = 4; // A list of the last N error instances
 }
 
 message ErrorInstance {
     Error error = 1;
     string uuid = 2;
     string timestamp = 3; // RFC3339 format
-    HttpContext httpContext = 4;
+    string severity = 4;
+    HttpContext httpContext = 5;
 }
 
 message Error {

--- a/scraper/models.go
+++ b/scraper/models.go
@@ -9,6 +9,7 @@ type responsePayload struct {
 type errorAggregate struct {
 	AggregationKey string             `json:"aggregation_key"`
 	TotalCount     int                `json:"total_count"`
+	Severity       string             `json:"severity"`
 	LatestErrors   []errorWithContext `json:"latest_errors"`
 }
 
@@ -16,6 +17,7 @@ type errorWithContext struct {
 	Error       errorInstance `json:"error"`
 	UUID        string        `json:"uuid"`
 	Timestamp   time.Time     `json:"timestamp"`
+	Severity    string        `json:"severity"`
 	HTTPContext httpContext   `json:"http_context"`
 }
 

--- a/scraper/sample-response1.json
+++ b/scraper/sample-response1.json
@@ -3,6 +3,7 @@
         {
             "aggregation_key": "com.soundcloud.Foon@e28e036e",
             "total_count": 2,
+            "severity": "error",
             "latest_errors": [
                 {
                     "error": {
@@ -15,6 +16,7 @@
                     },
                     "uuid": "uuid1",
                     "timestamp": "2018-09-13T16:23:30.630Z",
+                    "severity": "error",
                     "http_context": {
                         "request_method": "GET",
                         "request_url": "http://url",
@@ -34,6 +36,7 @@
                     },
                     "uuid": "uuid2",
                     "timestamp": "2018-09-13T16:25:30.630Z",
+                    "severity": "error",
                     "http_context": {
                         "request_method": "GET",
                         "request_url": "http://url",

--- a/scraper/sample-response2.json
+++ b/scraper/sample-response2.json
@@ -3,6 +3,7 @@
         {
             "aggregation_key": "com.soundcloud.Foon@e28e036e",
             "total_count": 2,
+            "severity": "error",
             "latest_errors": [
                 {
                     "error": {
@@ -15,6 +16,7 @@
                     },
                     "uuid": "uuid3",
                     "timestamp": "2018-09-13T16:24:30.630Z",
+                    "severity": "error",
                     "http_context": {
                         "request_method": "GET",
                         "request_url": "http://url",
@@ -34,6 +36,7 @@
                     },
                     "uuid": "uuid4",
                     "timestamp": "2018-09-13T16:26:30.630Z",
+                    "severity": "error",
                     "http_context": {
                         "request_method": "GET",
                         "request_url": "http://url",

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -152,6 +152,10 @@ const ErrorComponent =  (props: Props) => {
             {props.activeError.total_count}
           </ListGroupItem>
           <ListGroupItem>
+            <h4 className="list-group-item-heading"> Severity</h4>
+            {props.activeError.severity}
+          </ListGroupItem>
+          <ListGroupItem>
             <h4 className="list-group-item-heading"> Last Occurrence</h4>
             {renderLastOccurrence(props.activeError.latest_errors[0].timestamp)}
           </ListGroupItem>

--- a/web/src/components/SideBar.less
+++ b/web/src/components/SideBar.less
@@ -1,0 +1,11 @@
+.sidebar-item-error {
+    border-left: 3px solid #de4c4ccd;
+}
+
+.sidebar-item-warning {
+    border-left: 3px solid #ded24ccd;
+}
+
+.sidebar-item-info {
+    border-left: 3px solid #4ccfdecd;
+}

--- a/web/src/components/SideBar.tsx
+++ b/web/src/components/SideBar.tsx
@@ -1,3 +1,4 @@
+import "SideBar.less"
 import * as React from "react";
 import { ListGroup, ListGroupItem } from "react-bootstrap";
 
@@ -22,6 +23,16 @@ interface DefaultsProps {
 
 type Props = ConnectedProps & DispatchProps & DefaultsProps & RouteComponentProps<{service: string}>
 
+const sidebarItemClass = (error: AggregatedError): string => {
+  if (error.severity === "info") {
+    return "sidebar-item-info"
+  } else if (error.severity === "warning") {
+    return "sidebar-item-warning"
+  } else {
+    return "sidebar-item-error"
+  }
+}
+
 const SideBar = (props: Props) => {
 
   const renderNavItems = () => {
@@ -30,7 +41,7 @@ const SideBar = (props: Props) => {
     } else {
       return props.errors.map((error, index) => {
         return (
-          <ListGroupItem className="sidebar-item" onClick={_ => props.handleErrorSelect(error.aggregation_key)} active={ props.activeError === undefined ? false : error.aggregation_key === props.activeError.aggregation_key } key={index}>
+          <ListGroupItem className={"sidebar-item" + " " + sidebarItemClass(error)} onClick={_ => props.handleErrorSelect(error.aggregation_key)} active={ props.activeError === undefined ? false : error.aggregation_key === props.activeError.aggregation_key } key={index}>
             {error.aggregation_key} <span className="badge">{error.total_count}</span>
           </ListGroupItem>
         )

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -18,12 +18,14 @@ export interface Error {
     "cause"?: Error
   },
   "timestamp"?: number,
+  "severity"?: string,
   "http_context"?: HttpContext
 }
 
 export interface AggregatedError {
   "aggregation_key"?: string,
   "total_count"?: number,
+  "severity"?: string,
   "latest_errors"?: Error
 }
 


### PR DESCRIPTION
  - Severity levels can be used for tracking rescued exceptions or other
  lower priority error information.
  - The default is error. Warning and info are now supported too.
  - The UI  gives a hint of the severity level using left border
  coloring in the sidebar. In addition, it includes the severity level
  in the Error detail view.
  - The behaviour of how severity levels are aggregated is undefined
  (currently we take the last value on each aggregation).