### PR TITLE
Provide a mock target for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ web/.module-cache
 .kube
 target/
 periskop
+mock-target
 web/lint-reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,14 @@ Run everything (note that a different port will be used):
 make run
 ```
 
+Periskop needs something to scrape in order to show errors in the UI. In development, a mock target returning
+static responses can be used for this purpose (periskop is configured to point to it by default). To run the mock
+server:
+
+```bash
+make run-mock-target
+```
+
 ## Testing
 
 Running the API tests:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean run-web
+.PHONY: clean setup-web ci-setup-web build-web run-api run-mock-target run-web run build-api test-api lint-api
 
 WEB_FOLDER := web
 PORT := 7777
@@ -17,6 +17,9 @@ build-web:
 
 run-api:
 	GO111MODULE=on go build -o periskop && ./periskop -port=$(PORT) -config ./config.dev.yaml
+
+run-mock-target:
+	GO111MODULE=on go build -o mock-target mocktarget/mocktarget.go && ./mock-target
 
 run-web:
 	npm start --prefix $(WEB_FOLDER)

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -7,4 +7,4 @@ services:
       port: 7778
     scraper:
       endpoint: /errors
-      refresh_interval: 30s
+      refresh_interval: 10s

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,17 +1,10 @@
 services:
-  - name: service1
+  - name: mock-target
     service_discovery:
-      name: service1.host
+      name: localhost
       refresh_interval: 45s
-      type: SRV
+      type: A
+      port: 7778
     scraper:
-      endpoint: /-/exceptions
+      endpoint: /errors
       refresh_interval: 30s
-  - name: service2
-    service_discovery:
-      name: service2.host
-      refresh_interval: 45s
-      type: SRV
-    scraper:
-      endpoint: /-/exceptions
-      refresh_interval: 15s

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type ServiceDiscovery struct {
 	Name            string        `yaml:"name"`
 	Type            string        `yaml:"type"`
 	RefreshInterval time.Duration `yaml:"refresh_interval"`
+	Port            int           `yaml:"port"`
 }
 
 type Scraper struct {

--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -1,0 +1,56 @@
+{
+    "aggregated_errors": [
+        {
+            "aggregation_key": "java.lang.RuntimeException@123",
+            "total_count": 250,
+            "severity": "error",
+            "latest_errors": [
+                {
+                    "error": {
+                        "class": "java.lang.RuntimeException",
+                        "message": "Nooooes!",
+                        "stacktrace": [],
+                        "cause": null
+                    },
+                    "uuid": "e81e56ff-7f65-4279-817f-dd607585b9e0",
+                    "timestamp": "2019-10-11T12:46:25.595Z",
+                    "severity": "error",
+                    "http_context": {
+                        "request_method": "GET",
+                        "request_url": "http://badrequest.org/me",
+                        "request_headers": {
+                            "accept": "application/json",
+                            "host": "badrequest.org"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "aggregation_key": "java.lang.Exception@456",
+            "total_count": 44,
+            "severity": "warning",
+            "latest_errors": [
+                {
+                    "error": {
+                        "class": "java.lang.Exception",
+                        "message": "Something bad",
+                        "stacktrace": [],
+                        "cause": null
+                    },
+                    "uuid": "e81e56ff-7f65-4279-1234-dd6075855555",
+                    "timestamp": "2019-09-11T11:46:25.333Z",
+                    "severity": "error",
+                    "http_context": {
+                        "request_method": "GET",
+                        "request_url": "http://badrequest.org/another-endpoint",
+                        "request_headers": {
+                            "accept": "application/json",
+                            "host": "badrequest.org"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/mocktarget/mocktarget.go
+++ b/mocktarget/mocktarget.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+const port = "7778"
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	body, _ := ioutil.ReadFile("mocktarget/errors.json")
+	fmt.Fprintln(w, string(body))
+}
+
+func main() {
+	http.HandleFunc("/errors", handler)
+	address := fmt.Sprintf(":%s", port)
+	log.Printf("Serving on address %s", address)
+	log.Fatal(http.ListenAndServe(address, nil))
+}

--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -33,6 +33,7 @@ func NewResolver(c config.Service) SRVResolver {
 		Names:           names,
 		RefreshInterval: d,
 		Type:            c.ServiceDiscovery.Type,
+		Port:            c.ServiceDiscovery.Port,
 	}
 	return SRVResolver{
 		dnsConfig: dnsConfig,


### PR DESCRIPTION
  - In order to faciliate development and make it easier for external
  developers to contribute, provide a mock target that can be used
  during development.
  - The mock target is a simple server returning a static response with
  fictitious errors. It runs on port 7778 and can be executed via a
  simple Makefile target,
  - The development configuration has been updated to point to the mock
  server. It will resolve localhost to 127.0.0.1. The configuration has
  been extended to be able to optionally provide a port.