### PR TITLE
Use prometheus's format for DNS service discovery config

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,7 +1,8 @@
 services:
   - name: mock-target
-    service_discovery:
-      name: localhost
+    dns_sd_configs:
+      names:
+        - localhost
       refresh_interval: 45s
       type: A
       port: 7778

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/prometheus/prometheus/discovery/dns"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -13,16 +14,9 @@ type PeriskopConfig struct {
 }
 
 type Service struct {
-	Name             string           `yaml:"name"`
-	ServiceDiscovery ServiceDiscovery `yaml:"service_discovery"`
-	Scraper          Scraper          `yaml:"scraper"`
-}
-
-type ServiceDiscovery struct {
-	Name            string        `yaml:"name"`
-	Type            string        `yaml:"type"`
-	RefreshInterval time.Duration `yaml:"refresh_interval"`
-	Port            int           `yaml:"port"`
+	Name                string       `yaml:"name"`
+	DNSServiceDiscovery dns.SDConfig `yaml:"dns_sd_configs"`
+	Scraper             Scraper      `yaml:"scraper"`
 }
 
 type Scraper struct {

--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -3,7 +3,6 @@ package servicediscovery
 import (
 	"context"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/dns"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/soundcloud/periskop/config"
@@ -24,19 +23,8 @@ type SRVResolver struct {
 }
 
 func NewResolver(c config.Service) SRVResolver {
-	d, err := model.ParseDuration(c.ServiceDiscovery.RefreshInterval.String())
-	if err != nil {
-		panic(err)
-	}
-	names := []string{c.ServiceDiscovery.Name}
-	dnsConfig := dns.SDConfig{
-		Names:           names,
-		RefreshInterval: d,
-		Type:            c.ServiceDiscovery.Type,
-		Port:            c.ServiceDiscovery.Port,
-	}
 	return SRVResolver{
-		dnsConfig: dnsConfig,
+		dnsConfig: c.DNSServiceDiscovery,
 	}
 }
 


### PR DESCRIPTION
  - As a preparatory step for implementing new service discovery strategies reusing prometheus's code
  - Note: this is a breaking change to the configuration format

Co-authored-by: Riccardo Ciovati <riccardo.ciovati@soundcloud.com>
Co-authored-by: Marc Tudurí <marc.tuduri@soundcloud.com>