### PR TITLE
Process and render exception causes

### DIFF
--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -10,7 +10,12 @@
                         "class": "java.lang.RuntimeException",
                         "message": "Nooooes!",
                         "stacktrace": [],
-                        "cause": null
+                        "cause": {
+                          "class": "java.lang.CauseException",
+                          "message": "I caused this",
+                          "stacktrace": [],
+                          "cause": null
+                        }
                     },
                     "uuid": "e81e56ff-7f65-4279-817f-dd607585b9e0",
                     "timestamp": "2019-10-11T12:46:25.595Z",

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -22,10 +22,10 @@ type ErrorWithContext struct {
 }
 
 type ErrorInstance struct {
-	Class      string   `json:"class"`
-	Message    string   `json:"message"`
-	Stacktrace []string `json:"stacktrace"`
-	Cause      *error   `json:"cause"`
+	Class      string         `json:"class"`
+	Message    string         `json:"message"`
+	Stacktrace []string       `json:"stacktrace"`
+	Cause      *ErrorInstance `json:"cause"`
 }
 
 type HTTPContext struct {

--- a/scraper/models.go
+++ b/scraper/models.go
@@ -22,10 +22,10 @@ type errorWithContext struct {
 }
 
 type errorInstance struct {
-	Class      string   `json:"class"`
-	Message    string   `json:"message"`
-	Stacktrace []string `json:"stacktrace"`
-	Cause      *error   `json:"error"`
+	Class      string         `json:"class"`
+	Message    string         `json:"message"`
+	Stacktrace []string       `json:"stacktrace"`
+	Cause      *errorInstance `json:"cause"`
 }
 
 type httpContext struct {

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -131,7 +131,7 @@ func toRepositoryErrorsWithContent(occurrences []errorWithContext) []repository.
 				Class:      occurrence.Error.Class,
 				Message:    occurrence.Error.Message,
 				Stacktrace: occurrence.Error.Stacktrace,
-				Cause:      nil, //TODO map the cause recursively
+				Cause:      toRepositoryErrorCause(&occurrence.Error),
 			},
 			HTTPContext: repository.HTTPContext{
 				RequestHeaders: occurrence.HTTPContext.RequestHeaders,
@@ -148,4 +148,16 @@ func severityWithFallback(severity string) string {
 		return "error"
 	}
 	return severity
+}
+
+func toRepositoryErrorCause(errorInstance *errorInstance) *repository.ErrorInstance {
+	if errorInstance.Cause == nil {
+		return nil
+	}
+	return &repository.ErrorInstance{
+		Class:      errorInstance.Cause.Class,
+		Message:    errorInstance.Cause.Message,
+		Stacktrace: errorInstance.Cause.Stacktrace,
+		Cause:      toRepositoryErrorCause(errorInstance.Cause),
+	}
 }

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { ListGroup, Table, Button, Badge } from "react-bootstrap"
 import * as moment from "moment"
-import { AggregatedError, Error, HttpContext, Headers, StoreState } from "data/types"
+import { AggregatedError, Error, HttpContext, Headers, StoreState, ErrorInstance } from "data/types"
 import { ButtonGroup } from "react-bootstrap"
 import { setCurrentExceptionIndex } from "data/errors"
 import { bindActionCreators, Dispatch, AnyAction } from "redux"
@@ -34,19 +34,29 @@ const ErrorComponent = (props: Props) => {
     props.setCurrentExceptionIndex(calculateNewIndex(props.latestExceptionIndex, 1, props.activeError.latest_errors.length))
   }
 
+  const renderErrorInstance = (errorInstance: ErrorInstance) => {
+    if (!errorInstance) return ""
+
+    return (
+      <div>
+        <ListGroup.Item>
+          <h4 className="list-group-item-heading"> Class</h4>
+          { errorInstance.class }
+        </ListGroup.Item>
+        { renderMessage(errorInstance.message) }
+        { renderStackTrace(errorInstance.stacktrace) }
+        { renderCause(errorInstance.cause) }
+      </div>
+    )
+  }
+
   const renderError = (error: Error) => {
-    if (error == null) return
+    if (!error) return ""
 
     return (
       <ListGroup variant="flush">
-        <ListGroup.Item>
-          <h4 className="list-group-item-heading"> Class</h4>
-          { error.error.class }
-        </ListGroup.Item>
-        { renderMessage(error.error.message) }
         { renderCurl(error.http_context) }
-        { renderStackTrace(error.error.stacktrace) }
-        { renderCause(error.error.cause) }
+        { renderErrorInstance(error.error) }
         { renderHttpContext(error.http_context) }
       </ListGroup>
     )
@@ -69,15 +79,15 @@ const ErrorComponent = (props: Props) => {
     return moment(new Date(ts * 1000)).fromNow()
   }
 
-  const renderCause = (cause: Error) => {
-    if (cause === null) {
+  const renderCause = (cause: ErrorInstance) => {
+    if (!cause) {
       return ""
     }
 
     return (
       <ListGroup.Item>
         <h4 className="list-group-item-heading"> Cause</h4>
-        { renderError(cause) }
+        { renderErrorInstance(cause) }
       </ListGroup.Item>
     )
   }

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -10,13 +10,15 @@ export interface HttpContext {
   "request_url"?: string
 }
 
+export interface ErrorInstance {
+  "class"?: string,
+  "message"?: string,
+  "stacktrace"?: string[],
+  "cause"?: ErrorInstance
+}
+
 export interface Error {
-  "error"?: {
-    "class"?: string,
-    "message"?: string,
-    "stacktrace"?: string[],
-    "cause"?: Error
-  },
+  "error"?: ErrorInstance,
   "timestamp"?: number,
   "severity"?: string,
   "http_context"?: HttpContext


### PR DESCRIPTION
This feature was left out in the original MVP.

 - Parses exception causes recursively in the backend, and renders them
    in the API. This allows rendering information that was already
    made available in client libraries.

Render exception causes in UI
  - Fixes the schema to accommodate what actually comes from the API
  - Reorder fields so that we can render the cause related fields
    together

Fixes #14 
![cause screenshot](https://user-images.githubusercontent.com/1193802/77781043-2eec7180-7055-11ea-9265-ee67febf054f.png)
