### PR TITLE
Do not render HTTP Context if missing

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -121,7 +121,7 @@ func TestErrorsForKnownServiceReturnsErrors(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	// nolint
-	expected := `[{"aggregation_key":"key","total_count":0,"severity":"error","latest_errors":[{"error":{"class":"","message":"","stacktrace":null,"cause":null},"uuid":"","timestamp":0,"severity":"error","http_context":{"request_method":"","request_url":"","request_headers":null}}]}]` + "\n"
+	expected := `[{"aggregation_key":"key","total_count":0,"severity":"error","latest_errors":[{"error":{"class":"","message":"","stacktrace":null,"cause":null},"uuid":"","timestamp":0,"severity":"error","http_context":null}]}]` + "\n"
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)

--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -19,15 +19,7 @@
                     },
                     "uuid": "e81e56ff-7f65-4279-817f-dd607585b9e0",
                     "timestamp": "2019-10-11T12:46:25.595Z",
-                    "severity": "error",
-                    "http_context": {
-                        "request_method": "GET",
-                        "request_url": "http://badrequest.org/me",
-                        "request_headers": {
-                            "accept": "application/json",
-                            "host": "badrequest.org"
-                        }
-                    }
+                    "severity": "error"
                 },
                 {
                     "error": {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -18,7 +18,7 @@ type ErrorWithContext struct {
 	UUID        string        `json:"uuid"`
 	Timestamp   int64         `json:"timestamp"`
 	Severity    string        `json:"severity"`
-	HTTPContext HTTPContext   `json:"http_context"`
+	HTTPContext *HTTPContext  `json:"http_context"`
 }
 
 type ErrorInstance struct {

--- a/representation/errors.proto
+++ b/representation/errors.proto
@@ -24,7 +24,7 @@ message Error {
     string class = 1;
     string message = 2;
     repeated string stacktrace = 3; // An ordered list of stack trace lines
-    Error cause = 4; // For exceptions triggered by other exceptions
+    Error cause = 4; // Optional, for exceptions triggered by other exceptions
 }
 
 message HttpContext {

--- a/representation/errors.proto
+++ b/representation/errors.proto
@@ -17,7 +17,7 @@ message ErrorInstance {
     string uuid = 2;
     string timestamp = 3; // RFC3339 format
     string severity = 4;
-    HttpContext httpContext = 5;
+    HttpContext httpContext = 5; // Optional
 }
 
 message Error {

--- a/scraper/models.go
+++ b/scraper/models.go
@@ -18,7 +18,7 @@ type errorWithContext struct {
 	UUID        string        `json:"uuid"`
 	Timestamp   time.Time     `json:"timestamp"`
 	Severity    string        `json:"severity"`
-	HTTPContext httpContext   `json:"http_context"`
+	HTTPContext *httpContext  `json:"http_context"`
 }
 
 type errorInstance struct {

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -133,11 +133,7 @@ func toRepositoryErrorsWithContent(occurrences []errorWithContext) []repository.
 				Stacktrace: occurrence.Error.Stacktrace,
 				Cause:      toRepositoryErrorCause(&occurrence.Error),
 			},
-			HTTPContext: repository.HTTPContext{
-				RequestHeaders: occurrence.HTTPContext.RequestHeaders,
-				RequestMethod:  occurrence.HTTPContext.RequestMethod,
-				RequestURL:     occurrence.HTTPContext.RequestURL,
-			},
+			HTTPContext: toRepositoryHttpContext(occurrence.HTTPContext),
 		})
 	}
 	return errors
@@ -159,5 +155,17 @@ func toRepositoryErrorCause(errorInstance *errorInstance) *repository.ErrorInsta
 		Message:    errorInstance.Cause.Message,
 		Stacktrace: errorInstance.Cause.Stacktrace,
 		Cause:      toRepositoryErrorCause(errorInstance.Cause),
+	}
+}
+
+func toRepositoryHttpContext(httpContext *httpContext) *repository.HTTPContext {
+	if httpContext == nil {
+		return nil
+	}
+
+	return &repository.HTTPContext{
+		RequestHeaders: httpContext.RequestHeaders,
+		RequestMethod:  httpContext.RequestMethod,
+		RequestURL:     httpContext.RequestURL,
 	}
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -133,7 +133,7 @@ func toRepositoryErrorsWithContent(occurrences []errorWithContext) []repository.
 				Stacktrace: occurrence.Error.Stacktrace,
 				Cause:      toRepositoryErrorCause(&occurrence.Error),
 			},
-			HTTPContext: toRepositoryHttpContext(occurrence.HTTPContext),
+			HTTPContext: toRepositoryHTTPContext(occurrence.HTTPContext),
 		})
 	}
 	return errors
@@ -158,7 +158,7 @@ func toRepositoryErrorCause(errorInstance *errorInstance) *repository.ErrorInsta
 	}
 }
 
-func toRepositoryHttpContext(httpContext *httpContext) *repository.HTTPContext {
+func toRepositoryHTTPContext(httpContext *httpContext) *repository.HTTPContext {
 	if httpContext == nil {
 		return nil
 	}


### PR DESCRIPTION
  - Makes HTTP Context optional on the server side
  - The Curl and HTTP Context subsections will be hidden in the UI when
    the context is missing.
  - Fixes #108 