### PR TITLE
Fix race condition

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/soundcloud/periskop/repository"
 )
 
-func NewHandler(r repository.ErrorsRepository) http.Handler {
+func NewHandler(r *repository.ErrorsRepository) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// Allow CORS requests for local development since API and frontend run on different ports
 		origin := req.Header.Get("Origin")
@@ -39,9 +39,9 @@ func extractServiceName(url string) (string, error) {
 	return "", errors.New("invalid path")
 }
 
-func errorsForService(w http.ResponseWriter, r repository.ErrorsRepository,
+func errorsForService(w http.ResponseWriter, r *repository.ErrorsRepository,
 	service string, numberOfOccurrencesPerError int) {
-	if repoErrors, err := r.GetErrors(service, numberOfOccurrencesPerError); err == nil {
+	if repoErrors, err := (*r).GetErrors(service, numberOfOccurrencesPerError); err == nil {
 		renderJSON(w, repoErrors)
 	} else {
 		metrics.ServiceErrors.WithLabelValues("get_errors").Inc()
@@ -49,8 +49,8 @@ func errorsForService(w http.ResponseWriter, r repository.ErrorsRepository,
 	}
 }
 
-func servicesList(w http.ResponseWriter, r repository.ErrorsRepository) {
-	renderJSON(w, r.GetServices())
+func servicesList(w http.ResponseWriter, r *repository.ErrorsRepository) {
+	renderJSON(w, (*r).GetServices())
 }
 
 func renderJSON(w http.ResponseWriter, value interface{}) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRandomPathReturnNotFound(t *testing.T) {
 	r := repository.NewInMemory()
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/whatever", nil)
 	rr := httptest.NewRecorder()
@@ -25,7 +25,7 @@ func TestRandomPathReturnNotFound(t *testing.T) {
 
 func TestServicesWithEmptyRepoReturnsSuccess(t *testing.T) {
 	r := repository.NewInMemory()
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/services/", nil)
 	rr := httptest.NewRecorder()
@@ -39,7 +39,7 @@ func TestServicesWithEmptyRepoReturnsSuccess(t *testing.T) {
 
 func TestServicesWithEmptyRepoReturnsEmptyArray(t *testing.T) {
 	r := repository.NewInMemory()
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/services/", nil)
 	rr := httptest.NewRecorder()
@@ -56,7 +56,7 @@ func TestServicesWithNonEmptyRepoReturnsServiceNames(t *testing.T) {
 	r := repository.NewInMemory()
 	r.StoreErrors("api-test", []repository.ErrorAggregate{})
 
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/services/", nil)
 	rr := httptest.NewRecorder()
@@ -71,7 +71,7 @@ func TestServicesWithNonEmptyRepoReturnsServiceNames(t *testing.T) {
 
 func TestErrorsForUnknownServiceReturnsNotFound(t *testing.T) {
 	r := repository.NewInMemory()
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/services/api-test/erros/", nil)
 	rr := httptest.NewRecorder()
@@ -87,7 +87,7 @@ func TestErrorsForKnownServiceReturnsSuccess(t *testing.T) {
 	r := repository.NewInMemory()
 	r.StoreErrors("api-test", []repository.ErrorAggregate{})
 
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/services/api-test/errors/", nil)
 	rr := httptest.NewRecorder()
@@ -114,7 +114,7 @@ func TestErrorsForKnownServiceReturnsErrors(t *testing.T) {
 			},
 		}})
 
-	handler := NewHandler(r)
+	handler := NewHandler(&r)
 
 	req, _ := http.NewRequest("GET", "/services/api-test/errors/", nil)
 	rr := httptest.NewRecorder()

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	fs := http.FileServer(http.Dir(webFolder))
 	http.Handle("/", fs)
 
-	http.Handle("/services/", api.NewHandler(repo))
+	http.Handle("/services/", api.NewHandler(&repo))
 	http.Handle("/metrics", promhttp.Handler())
 
 	address := fmt.Sprintf(":%s", *port)


### PR DESCRIPTION
Building Periskop with `go build -race` we enable debug mode for race conditions. Turns out we have a race condition while we store errors.

```
WARNING: DATA RACE
Write at 0x00c0000bdef0 by goroutine 70:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:202 +0x0
  github.com/soundcloud/periskop/repository.inMemoryRepository.StoreErrors()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/repository/repository.go:55 +0x5c
  github.com/soundcloud/periskop/scraper.store()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/scraper/scraper.go:123 +0x5de
  github.com/soundcloud/periskop/scraper.Scraper.Scrape()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/scraper/scraper.go:76 +0x159

Previous write at 0x00c0000bdef0 by goroutine 69:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:202 +0x0
  github.com/soundcloud/periskop/repository.inMemoryRepository.StoreErrors()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/repository/repository.go:55 +0x5c
  github.com/soundcloud/periskop/scraper.store()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/scraper/scraper.go:123 +0x5de
  github.com/soundcloud/periskop/scraper.Scraper.Scrape()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/scraper/scraper.go:76 +0x159

Goroutine 70 (running) created at:
  main.main()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/main.go:53 +0x830

Goroutine 69 (running) created at:
  main.main()
      /home/marctc/workspace/go/src/github.com/soundcloud/periskop/main.go:53 +0x830

```