### PR TITLE
Implements errors sorting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Marc Tuduri <marctc@gmail.com>
 Michael Smith <michael.smith@soundcloud.com>
 Niko Dziemba <niko.dziemba@soundcloud.com>
 Riccardo Ciovati <riccardo.ciovati@soundcloud.com>
+Tiago Taquelim <tiago.taquelim.ferreira@gmail.com>

--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -44,7 +44,7 @@
         },
         {
             "aggregation_key": "java.lang.Exception@456",
-            "total_count": 44,
+            "total_count": 440,
             "severity": "warning",
             "latest_errors": [
                 {

--- a/web/src/components/SideBar.scss
+++ b/web/src/components/SideBar.scss
@@ -9,3 +9,10 @@
 .sidebar-item-info {
     border-left: 3px solid #4ccfdecd;
 }
+
+.grid-component {
+    &-actions {
+        display: flex;
+        padding-bottom: 15px;
+    }
+}

--- a/web/src/components/SideBar.tsx
+++ b/web/src/components/SideBar.tsx
@@ -10,17 +10,16 @@ import { RouteComponentProps, withRouter } from "react-router";
 
 interface DispatchProps {
   setActiveError: (notifcation: string) => void
-  setActiveErrorSortFilter: (filter: SortFilters) => void,
+  setActiveErrorSortFilter: (filter: SortFilters) => void
 }
 
 interface ConnectedProps {
   activeError: AggregatedError
+  activeSortFilter: SortFilters
 }
 
 interface DefaultsProps {
-  errors: AggregatedError[],
-  activeSortFilter: SortFilters,
-  setActiveErrorSortFilter: (filter: SortFilters) => void,
+  errors: AggregatedError[]
   handleErrorSelect: (errorKey: string) => void
 }
 

--- a/web/src/components/SideBar.tsx
+++ b/web/src/components/SideBar.tsx
@@ -1,15 +1,16 @@
 import "SideBar.scss"
 import * as React from "react";
-import { ListGroup, Badge } from "react-bootstrap";
+import { ListGroup, Badge, DropdownButton, ButtonGroup, Dropdown } from "react-bootstrap";
 
 import { bindActionCreators, Dispatch, AnyAction } from "redux"
 import { connect } from "react-redux"
-import { StoreState, AggregatedError } from "data/types"
-import { setActiveError } from "data/errors"
+import { StoreState, AggregatedError, SortFilters } from "data/types"
+import { setActiveError, setActiveErrorSortFilter } from "data/errors"
 import { RouteComponentProps, withRouter } from "react-router";
 
 interface DispatchProps {
   setActiveError: (notifcation: string) => void
+  setActiveErrorSortFilter: (filter: SortFilters) => void,
 }
 
 interface ConnectedProps {
@@ -18,10 +19,17 @@ interface ConnectedProps {
 
 interface DefaultsProps {
   errors: AggregatedError[],
+  activeSortFilter: SortFilters,
+  setActiveErrorSortFilter: (filter: SortFilters) => void,
   handleErrorSelect: (errorKey: string) => void
 }
 
-type Props = ConnectedProps & DispatchProps & DefaultsProps & RouteComponentProps<{service: string}>
+type Props = ConnectedProps & DispatchProps & DefaultsProps & RouteComponentProps<{ service: string }>
+
+export const SORT_FILTERS = {
+  "latest_occurrence": "Latest Occurence",
+  "event_count": "Event Count",
+}
 
 const sidebarItemClass = (error: AggregatedError): string => {
   if (error.severity === "info") {
@@ -38,19 +46,50 @@ const SideBar = (props: Props) => {
   const renderNavItems = () => {
     if (props.errors.length === 0) {
       return <div>no errors returned from api</div>
-    } else {
-      return props.errors.map((error, index) => {
-        return (
-          <ListGroup.Item action className={"sidebar-item" + " " + sidebarItemClass(error)} onClick={_ => props.handleErrorSelect(error.aggregation_key)} active={ props.activeError === undefined ? false : error.aggregation_key === props.activeError.aggregation_key } key={index}>
-            {error.aggregation_key} <Badge variant="secondary" className="float-right">{error.total_count}</Badge>
-          </ListGroup.Item>
-        )
-      })
     }
+
+    return props.errors.map((error, index) => {
+      return (
+        <ListGroup.Item
+          action className={"sidebar-item" + " " + sidebarItemClass(error)}
+          onClick={_ => props.handleErrorSelect(error.aggregation_key)}
+          active={props.activeError === undefined ? false : error.aggregation_key === props.activeError.aggregation_key}
+          key={index}
+        >
+          {error.aggregation_key} <Badge variant="secondary" className="float-right">{error.total_count}</Badge>
+        </ListGroup.Item>
+      )
+    })
+  }
+
+  const renderActions = () =>  {
+    return (
+      <div className='grid-component-actions'>
+        <DropdownButton
+          id="sort-btn"
+          as={ButtonGroup}
+          variant="secondary"
+          title={`Sort by: ${SORT_FILTERS[props.activeSortFilter]}`}
+          size="sm"
+        >
+          {Object.keys(SORT_FILTERS).map((filter: SortFilters) => (
+            <Dropdown.Item
+              key={`${filter}-sortFilter`}
+              active={filter === props.activeSortFilter}
+              onClick={_ => props.setActiveErrorSortFilter(filter)}
+            >
+              {SORT_FILTERS[filter]}
+            </Dropdown.Item>
+          ))}
+        </DropdownButton>
+      </div>
+      )
   }
 
   return (
     <div className="grid-component">
+      {renderActions()}
+
       <ListGroup>
         {renderNavItems()}
       </ListGroup>
@@ -59,12 +98,13 @@ const SideBar = (props: Props) => {
 }
 
 const matchDispatchToProps = (dispatch: Dispatch<AnyAction>): DispatchProps => {
-  return bindActionCreators({ setActiveError }, dispatch)
+  return bindActionCreators({ setActiveError, setActiveErrorSortFilter }, dispatch)
 }
 
 const mapStateToProps = (state: StoreState) => {
   return {
     activeError: state.errorsReducer.activeError,
+    activeSortFilter: state.errorsReducer.activeSortFilter,
   }
 }
 

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -1,4 +1,5 @@
 import * as RemoteData from "data/remote-data";
+import { SORT_FILTERS } from "components/SideBar"
 
 export type Headers = {
   [key: string]: any
@@ -35,12 +36,15 @@ export type ServicesState = {
   services: RemoteData.RemoteData<any, string[]>
 } 
 
+export type SortFilters = keyof typeof SORT_FILTERS
+
 export type ErrorsState = {
   errors: RemoteData.RemoteData<any, AggregatedError[]>
   activeError?: AggregatedError,
   updatedAt?: number,
   activeService?: string,
   latestExceptionIndex: number
+  activeSortFilter: SortFilters,  
 }
 
 export type StoreState = {

--- a/web/src/util/errors.ts
+++ b/web/src/util/errors.ts
@@ -1,0 +1,9 @@
+import { AggregatedError } from "data/types"
+
+export const errorSortByLatestOccurrence = (errors: AggregatedError[]) => {
+  return [...errors].sort((a, b) => b.latest_errors[0].timestamp - a.latest_errors[0].timestamp)
+}
+
+export const errorSortByEventCount = (errors: AggregatedError[]) => {
+  return [...errors].sort((a, b) => a.total_count >= b.total_count ? -1 : 1)
+}


### PR DESCRIPTION
Fixes #12 

*Implements:
 - Sorting dropdown button for the errors on the sidebar.

Dev notes from this PR:
 - created a `utils/errors` with some utilities for errors manipulation.
 - for the dropdown sorting used the bootstrap one with default styling.
 - added the sorting button in a 'actions' div where maybe will be more buttons such as Searching.
 - if the errors sidebar has many items until it can scroll the actions div should be fixed on top (maybe for a future pr).