### PR TITLE
Add API method to resolve errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,8 @@ run:
   skip-dirs:
     - web
     - representation
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
+      - gomnd

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - wsl
     - gochecknoinits
     - godox
+    - interfacer
 run:
   skip-dirs:
     - web

--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,21 @@ func NewErrorsListHandler(r *repository.ErrorsRepository) http.Handler {
 	})
 }
 
+func NewErrorDeleteHandler(r *repository.ErrorsRepository) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		allowCORS(w, req)
+		vars := mux.Vars(req)
+
+		if service, found := vars["service_name"]; found {
+			errKey := vars["error_key"]
+			(*r).DeleteError(service, errKey)
+			w.WriteHeader(http.StatusNoContent)
+		} else {
+			http.NotFound(w, req)
+		}
+	})
+}
+
 func allowCORS(w http.ResponseWriter, req *http.Request) {
 	// Allow CORS requests for local development since API and frontend run on different ports
 	origin := req.Header.Get("Origin")

--- a/api/api.go
+++ b/api/api.go
@@ -60,6 +60,7 @@ func CORSLocalhostMiddleware(r *mux.Router) mux.MiddlewareFunc {
 			origin := req.Header.Get("Origin")
 			if strings.HasPrefix(origin, "http://localhost:") {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
 			}
 			next.ServeHTTP(w, req)
 		})

--- a/api/api.go
+++ b/api/api.go
@@ -45,7 +45,10 @@ func NewErrorDeleteHandler(r *repository.ErrorsRepository) http.Handler {
 
 		if service, found := vars["service_name"]; found {
 			errKey := vars["error_key"]
-			(*r).DeleteError(service, errKey)
+			err := (*r).DeleteError(service, errKey)
+			if err != nil {
+				http.NotFound(w, req)
+			}
 			w.WriteHeader(http.StatusNoContent)
 		} else {
 			http.NotFound(w, req)

--- a/api/api.go
+++ b/api/api.go
@@ -36,13 +36,13 @@ func NewErrorsListHandler(r *repository.ErrorsRepository) http.Handler {
 	})
 }
 
-func NewErrorDeleteHandler(r *repository.ErrorsRepository) http.Handler {
+func NewErrorResolveHandler(r *repository.ErrorsRepository) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		vars := mux.Vars(req)
 
 		if service, found := vars["service_name"]; found {
 			errKey := vars["error_key"]
-			err := (*r).DeleteError(service, errKey)
+			err := (*r).ResolveError(service, errKey)
 			if err != nil {
 				http.NotFound(w, req)
 			}

--- a/api/api.go
+++ b/api/api.go
@@ -2,48 +2,48 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/soundcloud/periskop/metrics"
 	"github.com/soundcloud/periskop/repository"
 )
 
-func NewHandler(r *repository.ErrorsRepository) http.Handler {
+func NewServicesListHandler(r *repository.ErrorsRepository) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// Allow CORS requests for local development since API and frontend run on different ports
-		origin := req.Header.Get("Origin")
-		if strings.HasPrefix(origin, "http://localhost:") {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
+		allowCORS(w, req)
+		err := servicesList(w, r)
+		if err != nil {
+			metrics.ErrorCollector.ReportWithHTTPRequest(err, req)
 		}
+	})
+}
 
-		path := strings.TrimPrefix(req.URL.Path, "/services/")
+func NewErrorsListHandler(r *repository.ErrorsRepository) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		allowCORS(w, req)
+		vars := mux.Vars(req)
 		numberOfOccurrencesPerError := 10
 
-		if len(path) == 0 {
-			err := servicesList(w, r)
-			if err != nil {
-				metrics.ErrorCollector.ReportWithHTTPRequest(err, req)
-			}
-		} else if service, err := extractServiceName(path); err == nil {
-			err = errorsForService(w, r, service, numberOfOccurrencesPerError)
+		if service, found := vars["service_name"]; found {
+			err := errorsForService(w, r, service, numberOfOccurrencesPerError)
 			if err != nil {
 				metrics.ErrorCollector.ReportWithHTTPRequest(err, req)
 			}
 		} else {
-			metrics.ErrorCollector.ReportWithHTTPRequest(err, req)
 			http.NotFound(w, req)
 		}
 	})
 }
 
-func extractServiceName(url string) (string, error) {
-	if strings.HasSuffix(url, "/errors/") {
-		return strings.TrimSuffix(url, "/errors/"), nil
+func allowCORS(w http.ResponseWriter, req *http.Request) {
+	// Allow CORS requests for local development since API and frontend run on different ports
+	origin := req.Header.Get("Origin")
+	if strings.HasPrefix(origin, "http://localhost:") {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
 	}
-	return "", errors.New("invalid path")
 }
 
 func errorsForService(w http.ResponseWriter, r *repository.ErrorsRepository,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -116,10 +116,10 @@ func serveMockErrorList(rr *httptest.ResponseRecorder, r repository.ErrorsReposi
 	router.ServeHTTP(rr, req)
 }
 
-func TestDeleteErrorForUnknownServiceReturnsNotFound(t *testing.T) {
+func TestResolveErrorForUnknownServiceReturnsNotFound(t *testing.T) {
 	r := repository.NewInMemory()
 	rr := httptest.NewRecorder()
-	serveMockErrorDelete(rr, r, "api-test", "test")
+	serveMockErrorResolve(rr, r, "api-test", "test")
 
 	if status := rr.Code; status != http.StatusNotFound {
 		t.Errorf("handler returned wrong status code: got %v want %v",
@@ -127,12 +127,12 @@ func TestDeleteErrorForUnknownServiceReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestDeleteErrorsReturnsSuccess(t *testing.T) {
+func TestResolveErrorsReturnsSuccess(t *testing.T) {
 	r := repository.NewInMemory()
 	r.StoreErrors("api-test", []repository.ErrorAggregate{})
 
 	rr := httptest.NewRecorder()
-	serveMockErrorDelete(rr, r, "api-test", "test")
+	serveMockErrorResolve(rr, r, "api-test", "test")
 
 	if status := rr.Code; status != http.StatusNoContent {
 		t.Errorf("handler returned wrong status code: got %v want %v",
@@ -140,9 +140,9 @@ func TestDeleteErrorsReturnsSuccess(t *testing.T) {
 	}
 }
 
-func serveMockErrorDelete(rr *httptest.ResponseRecorder, r repository.ErrorsRepository,
+func serveMockErrorResolve(rr *httptest.ResponseRecorder, r repository.ErrorsRepository,
 	serviceName string, errKey string) {
-	handler := NewErrorDeleteHandler(&r)
+	handler := NewErrorResolveHandler(&r)
 	router := mux.NewRouter()
 	router.Handle("/services/{service_name}/errors/{error_key}/", handler).Methods(http.MethodDelete)
 	req, _ := http.NewRequest("DELETE", fmt.Sprintf("/services/%s/errors/%s/", serviceName, errKey), nil)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/soundcloud/periskop
 
 require (
 	github.com/go-kit/kit v0.10.0
+	github.com/gorilla/mux v1.7.4
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soundcloud/periskop-go"
 
@@ -65,10 +66,14 @@ func main() {
 
 	errorExporter := periskop.NewErrorExporter(&metrics.ErrorCollector)
 	periskopHandler := periskop.NewHandler(errorExporter)
+	r := mux.NewRouter()
 
-	http.Handle("/services/", api.NewHandler(&repo))
+	r.Handle("/services/", api.NewServicesListHandler(&repo)).Methods(http.MethodGet)
+	r.Handle("/services/{service_name}/errors", api.NewErrorsListHandler(&repo)).Methods(http.MethodGet)
+
 	http.Handle("/metrics", promhttp.Handler())
 	http.Handle("/errors", periskopHandler)
+	http.Handle("/", r)
 
 	address := fmt.Sprintf(":%s", *port)
 	log.Printf("Serving on address %s", address)

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	r.Handle("/services/{service_name}/errors/{error_key}/",
 		api.NewErrorDeleteHandler(&repo)).Methods(http.MethodDelete)
 	r.Handle("/", fs)
+	r.Use(api.CORSLocalhostMiddleware(r))
 	http.Handle("/", r)
 
 	// Telemetry endpoints

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	r.Handle("/services/{service_name}/errors/",
 		api.NewErrorsListHandler(&repo)).Methods(http.MethodGet)
 	r.Handle("/services/{service_name}/errors/{error_key}/",
-		api.NewErrorDeleteHandler(&repo)).Methods(http.MethodDelete, http.MethodOptions)
+		api.NewErrorResolveHandler(&repo)).Methods(http.MethodDelete, http.MethodOptions)
 	r.Handle("/", fs)
 	r.Use(api.CORSLocalhostMiddleware(r))
 	http.Handle("/", r)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 		api.NewServicesListHandler(&repo)).Methods(http.MethodGet)
 	r.Handle("/services/{service_name}/errors/",
 		api.NewErrorsListHandler(&repo)).Methods(http.MethodGet)
-	r.Handle("/services/{service_name}/errors/{error_key}/",
+	r.Handle("/services/{service_name}/errors/{error_key:.*}/",
 		api.NewErrorResolveHandler(&repo)).Methods(http.MethodDelete, http.MethodOptions)
 	r.Handle("/", fs)
 	r.Use(api.CORSLocalhostMiddleware(r))

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	r.Handle("/services/{service_name}/errors/",
 		api.NewErrorsListHandler(&repo)).Methods(http.MethodGet)
 	r.Handle("/services/{service_name}/errors/{error_key}/",
-		api.NewErrorDeleteHandler(&repo)).Methods(http.MethodDelete)
+		api.NewErrorDeleteHandler(&repo)).Methods(http.MethodDelete, http.MethodOptions)
 	r.Handle("/", fs)
 	r.Use(api.CORSLocalhostMiddleware(r))
 	http.Handle("/", r)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -85,3 +85,16 @@ func (r *inMemoryRepository) GetErrors(serviceName string, numberOfErrors int) (
 	metrics.ServiceErrors.WithLabelValues("service_not_found").Inc()
 	return nil, fmt.Errorf("service %s not found", serviceName)
 }
+
+func (r *inMemoryRepository) DeleteError(serviceName string, key string) {
+	if value, ok := r.AggregatedError.Load(serviceName); ok {
+		value, _ := value.([]ErrorAggregate)
+		newValues := []ErrorAggregate{}
+		for _, errorObj := range value {
+			if errorObj.AggregationKey != key {
+				newValues = append(newValues, errorObj)
+			}
+		}
+		r.StoreErrors(serviceName, newValues)
+	}
+}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -40,7 +40,7 @@ type ErrorsRepository interface {
 	StoreErrors(serviceName string, errors []ErrorAggregate)
 	GetServices() []string
 	GetErrors(serviceName string, numberOfErrors int) ([]ErrorAggregate, error)
-	DeleteError(serviceName string, key string)
+	DeleteError(serviceName string, key string) error
 }
 
 func NewInMemory() ErrorsRepository {
@@ -87,7 +87,7 @@ func (r *inMemoryRepository) GetErrors(serviceName string, numberOfErrors int) (
 	return nil, fmt.Errorf("service %s not found", serviceName)
 }
 
-func (r *inMemoryRepository) DeleteError(serviceName string, key string) {
+func (r *inMemoryRepository) DeleteError(serviceName string, key string) error {
 	if value, ok := r.AggregatedError.Load(serviceName); ok {
 		value, _ := value.([]ErrorAggregate)
 		newValues := []ErrorAggregate{}
@@ -97,5 +97,7 @@ func (r *inMemoryRepository) DeleteError(serviceName string, key string) {
 			}
 		}
 		r.StoreErrors(serviceName, newValues)
+		return nil
 	}
+	return fmt.Errorf("service %s not found", serviceName)
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -40,6 +40,7 @@ type ErrorsRepository interface {
 	StoreErrors(serviceName string, errors []ErrorAggregate)
 	GetServices() []string
 	GetErrors(serviceName string, numberOfErrors int) ([]ErrorAggregate, error)
+	DeleteError(serviceName string, key string)
 }
 
 func NewInMemory() ErrorsRepository {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -40,7 +40,7 @@ type ErrorsRepository interface {
 	StoreErrors(serviceName string, errors []ErrorAggregate)
 	GetServices() []string
 	GetErrors(serviceName string, numberOfErrors int) ([]ErrorAggregate, error)
-	DeleteError(serviceName string, key string) error
+	ResolveError(serviceName string, key string) error
 }
 
 func NewInMemory() ErrorsRepository {
@@ -87,7 +87,7 @@ func (r *inMemoryRepository) GetErrors(serviceName string, numberOfErrors int) (
 	return nil, fmt.Errorf("service %s not found", serviceName)
 }
 
-func (r *inMemoryRepository) DeleteError(serviceName string, key string) error {
+func (r *inMemoryRepository) ResolveError(serviceName string, key string) error {
 	if value, ok := r.AggregatedError.Load(serviceName); ok {
 		value, _ := value.([]ErrorAggregate)
 		newValues := []ErrorAggregate{}

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"testing"
+)
+
+func TestDeleteError(t *testing.T) {
+	serviceName := "test-service"
+	er := &inMemoryRepository{}
+	er.AggregatedError.Store(serviceName, []ErrorAggregate{
+		{AggregationKey: "test-error-0"},
+		{AggregationKey: "test-error-1"},
+	})
+	er.DeleteError(serviceName, "test-error-0")
+	if value, ok := er.AggregatedError.Load(serviceName); ok {
+		value, _ := value.([]ErrorAggregate)
+		if len(value) != 1 {
+			t.Errorf("Expected 1 element, Found %d", len(value))
+		}
+	}
+}

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -11,7 +11,10 @@ func TestDeleteError(t *testing.T) {
 		{AggregationKey: "test-error-0"},
 		{AggregationKey: "test-error-1"},
 	})
-	er.DeleteError(serviceName, "test-error-0")
+	err := er.DeleteError(serviceName, "test-error-0")
+	if err != nil {
+		t.Errorf("deleting the error")
+	}
 	if value, ok := er.AggregatedError.Load(serviceName); ok {
 		value, _ := value.([]ErrorAggregate)
 		if len(value) != 1 {

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 )
 
-func TestDeleteError(t *testing.T) {
+func TestResolveErrorError(t *testing.T) {
 	serviceName := "test-service"
 	er := &inMemoryRepository{}
 	er.AggregatedError.Store(serviceName, []ErrorAggregate{
 		{AggregationKey: "test-error-0"},
 		{AggregationKey: "test-error-1"},
 	})
-	err := er.DeleteError(serviceName, "test-error-0")
+	err := er.ResolveError(serviceName, "test-error-0")
 	if err != nil {
 		t.Errorf("deleting the error")
 	}

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -3,12 +3,13 @@ import { ListGroup, Table, Button, Badge } from "react-bootstrap"
 import * as moment from "moment"
 import { AggregatedError, Error, HttpContext, Headers, StoreState, ErrorInstance } from "data/types"
 import { ButtonGroup } from "react-bootstrap"
-import { setCurrentExceptionIndex } from "data/errors"
+import { setCurrentExceptionIndex, deleteError } from "data/errors"
 import { bindActionCreators, Dispatch, AnyAction } from "redux"
 import { connect } from "react-redux"
 
 interface ConnectedProps {
   activeError: AggregatedError,
+  activeService: string,
   latestExceptionIndex: number,
 }
 
@@ -185,7 +186,7 @@ const ErrorComponent: React.FC<Props> = (props) => {
   }
 
   const deleteError = () => {
-    props.deleteError("mock-target", props.activeError.aggregation_key)
+    props.deleteError(props.activeService, props.activeError.aggregation_key)
   }
     
   const renderAggregatedError = () => {
@@ -234,12 +235,13 @@ const ErrorComponent: React.FC<Props> = (props) => {
 const mapStateToProps = (state: StoreState) => {
   return {
     activeError: state.errorsReducer.activeError,
+    activeService: state.errorsReducer.activeService,
     latestExceptionIndex: state.errorsReducer.latestExceptionIndex,
   }
 }
 
 const matchDispatchToProps = (dispatch: Dispatch<AnyAction>): DispatchProps => {
-  return bindActionCreators({ setCurrentExceptionIndex }, dispatch)
+  return bindActionCreators({ setCurrentExceptionIndex, deleteError }, dispatch)
 }
 
 export default connect(mapStateToProps, matchDispatchToProps)(ErrorComponent)

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -3,7 +3,7 @@ import { ListGroup, Table, Button, Badge } from "react-bootstrap"
 import * as moment from "moment"
 import { AggregatedError, Error, HttpContext, Headers, StoreState, ErrorInstance } from "data/types"
 import { ButtonGroup } from "react-bootstrap"
-import { setCurrentExceptionIndex, deleteError } from "data/errors"
+import { setCurrentExceptionIndex, resolveError } from "data/errors"
 import { bindActionCreators, Dispatch, AnyAction } from "redux"
 import { connect } from "react-redux"
 
@@ -15,7 +15,7 @@ interface ConnectedProps {
 
 interface DispatchProps {
   setCurrentExceptionIndex: (num: number) => void,
-  deleteError: (service: string, errorKey: string) => void
+  resolveError: (service: string, errorKey: string) => void
 }
 
 type Props = ConnectedProps & DispatchProps
@@ -185,15 +185,15 @@ const ErrorComponent: React.FC<Props> = (props) => {
     )
   }
 
-  const deleteError = () => {
-    props.deleteError(props.activeService, props.activeError.aggregation_key)
+  const resolveError = () => {
+    props.resolveError(props.activeService, props.activeError.aggregation_key)
   }
     
   const renderAggregatedError = () => {
     return (
       <div className={"grid-component"}>
         <ButtonGroup className="float-right">
-          <Button variant="outline-danger" size="sm" onClick={() => deleteError()}>Delete</Button>
+          <Button variant="outline-danger" size="sm" onClick={() => resolveError()}>Resolve</Button>
         </ButtonGroup>
         <h3 className="list-group-item-heading"> Summary</h3>
         <ListGroup>
@@ -241,7 +241,7 @@ const mapStateToProps = (state: StoreState) => {
 }
 
 const matchDispatchToProps = (dispatch: Dispatch<AnyAction>): DispatchProps => {
-  return bindActionCreators({ setCurrentExceptionIndex, deleteError }, dispatch)
+  return bindActionCreators({ setCurrentExceptionIndex, resolveError }, dispatch)
 }
 
 export default connect(mapStateToProps, matchDispatchToProps)(ErrorComponent)

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -13,7 +13,8 @@ interface ConnectedProps {
 }
 
 interface DispatchProps {
-  setCurrentExceptionIndex: (num: number) => void
+  setCurrentExceptionIndex: (num: number) => void,
+  deleteError: (service: string, errorKey: string) => void
 }
 
 type Props = ConnectedProps & DispatchProps
@@ -183,9 +184,16 @@ const ErrorComponent: React.FC<Props> = (props) => {
     )
   }
 
+  const deleteError = () => {
+    props.deleteError("mock-target", props.activeError.aggregation_key)
+  }
+    
   const renderAggregatedError = () => {
     return (
       <div className={"grid-component"}>
+        <ButtonGroup className="float-right">
+          <Button variant="outline-danger" size="sm" onClick={() => deleteError()}>Delete</Button>
+        </ButtonGroup>
         <h3 className="list-group-item-heading"> Summary</h3>
         <ListGroup>
           <ListGroup.Item>
@@ -210,7 +218,7 @@ const ErrorComponent: React.FC<Props> = (props) => {
           <Button variant="outline-dark" size="sm" onClick={() => showPreviousException()}>Previous</Button>
           <Button variant="outline-dark" size="sm" onClick={() => showNextException()} >Next</Button>
         </ButtonGroup>
-        <h3 className="list-group-item-heading"> Latest Occurences <Badge variant="light">{props.latestExceptionIndex+1 + "/" + props.activeError.latest_errors.length}</Badge></h3>
+        <h3 className="list-group-item-heading"> Latest Occurrences <Badge variant="light">{props.latestExceptionIndex+1 + "/" + props.activeError.latest_errors.length}</Badge></h3>
         {renderError(props.activeError.latest_errors[props.latestExceptionIndex]) }
       </div>
     )

--- a/web/src/data/errors.ts
+++ b/web/src/data/errors.ts
@@ -3,6 +3,7 @@ import * as RemoteData from "data/remote-data";
 import { registerReducer } from "data/store"
 import { AggregatedError, ErrorsState, SortFilters } from "data/types"
 import { errorSortByLatestOccurrence, errorSortByEventCount } from "util/errors"
+import { ThunkDispatch } from "redux-thunk";
 
 export const FETCH = "periskop/errors/FETCH"
 export const FETCH_SUCCESS = "periskop/errors/FETCH_SUCCESS"
@@ -10,6 +11,8 @@ export const FETCH_FAILURE = "periskop/errors/FETCH_FAILURE"
 export const SET_ACTIVE_ERROR = "periskop/errors/SET_ACTIVE_ERROR"
 export const SET_CURRENT_EXCEPTION_INDEX = "periskop/errors/SET_CURRENT_EXCEPTION_INDEX"
 export const SET_ERRORS_SORT_FILTER = "periskop/errors/SET_ERRORS_SORT_FILTER"
+export const DELETE_ERROR = "periskop/errors/DELETE_ERROR"
+export const DELETE_ERROR_FAILURE = "periskop/errors/DELETE_ERROR_FAILURE"
 
 export type ErrorsAction =
   | { type: typeof FETCH; service: string }
@@ -18,6 +21,8 @@ export type ErrorsAction =
   | { type: typeof SET_ACTIVE_ERROR; errorKey: string }
   | { type: typeof SET_CURRENT_EXCEPTION_INDEX; index: number }
   | { type: typeof SET_ERRORS_SORT_FILTER; filter: SortFilters }
+  | { type: typeof DELETE_ERROR; service: string, errorKey: String }
+  | { type: typeof DELETE_ERROR_FAILURE; service: string, errorKey: String }
 
 export const fetchErrors = (service: string) => {
   return (
@@ -56,6 +61,18 @@ export function fetchedErrorsFailed(error: any): ErrorsAction {
 
 export const setActiveErrorSortFilter = (filter: SortFilters) => {
   return { type: SET_ERRORS_SORT_FILTER, filter }
+}
+
+export const deleteError = (service: string, errorKey: string) => {
+  return (dispatch: ThunkDispatch<{}, {}, ErrorsAction>) => {
+    dispatch({ type: DELETE_ERROR, service: service, errorKey: errorKey })
+
+    return fetch(`${parseHostName()}services/${service}/errors/${errorKey}/`, {
+      method: 'DELETE'
+    })
+      .then((_) => dispatch(fetchErrors(service)))
+      .catch(err => dispatch({ type: DELETE_ERROR_FAILURE, service: service, errorKey: errorKey }))
+  }
 }
 
 const ErrorsSortActions = {

--- a/web/src/data/errors.ts
+++ b/web/src/data/errors.ts
@@ -11,8 +11,8 @@ export const FETCH_FAILURE = "periskop/errors/FETCH_FAILURE"
 export const SET_ACTIVE_ERROR = "periskop/errors/SET_ACTIVE_ERROR"
 export const SET_CURRENT_EXCEPTION_INDEX = "periskop/errors/SET_CURRENT_EXCEPTION_INDEX"
 export const SET_ERRORS_SORT_FILTER = "periskop/errors/SET_ERRORS_SORT_FILTER"
-export const DELETE_ERROR = "periskop/errors/DELETE_ERROR"
-export const DELETE_ERROR_FAILURE = "periskop/errors/DELETE_ERROR_FAILURE"
+export const RESOLVE_ERROR = "periskop/errors/RESOLVE_ERROR"
+export const RESOLVE_ERROR_FAILURE = "periskop/errors/RESOLVE_ERROR_FAILURE"
 
 export type ErrorsAction =
   | { type: typeof FETCH; service: string }
@@ -21,8 +21,8 @@ export type ErrorsAction =
   | { type: typeof SET_ACTIVE_ERROR; errorKey: string }
   | { type: typeof SET_CURRENT_EXCEPTION_INDEX; index: number }
   | { type: typeof SET_ERRORS_SORT_FILTER; filter: SortFilters }
-  | { type: typeof DELETE_ERROR; service: string, errorKey: String }
-  | { type: typeof DELETE_ERROR_FAILURE; service: string, errorKey: String }
+  | { type: typeof RESOLVE_ERROR; service: string, errorKey: String }
+  | { type: typeof RESOLVE_ERROR_FAILURE; service: string, errorKey: String }
 
 export const fetchErrors = (service: string) => {
   return (
@@ -63,15 +63,15 @@ export const setActiveErrorSortFilter = (filter: SortFilters) => {
   return { type: SET_ERRORS_SORT_FILTER, filter }
 }
 
-export const deleteError = (service: string, errorKey: string) => {
+export const resolveError = (service: string, errorKey: string) => {
   return (dispatch: ThunkDispatch<{}, {}, ErrorsAction>) => {
-    dispatch({ type: DELETE_ERROR, service: service, errorKey: errorKey })
+    dispatch({ type: RESOLVE_ERROR, service: service, errorKey: errorKey })
 
     return fetch(`${parseHostName()}services/${service}/errors/${errorKey}/`, {
       method: 'DELETE'
     })
       .then((_) => dispatch(fetchErrors(service)))
-      .catch(err => dispatch({ type: DELETE_ERROR_FAILURE, service: service, errorKey: errorKey }))
+      .catch(err => dispatch({ type: RESOLVE_ERROR_FAILURE, service: service, errorKey: errorKey }))
   }
 }
 


### PR DESCRIPTION
This PR adds the logic and API implementation to mark an error as resolved (by key) of a service (#129). This implementation required:

- Move logic per endpoint in handle functions.
- Added new endpoint in API to resolve an error of a service. Usage example.
```
curl -XDELETE '0.0.0.0:7777/services/periskop/errors/*url.Error@671731b4/'
```
- Since complexity of API increased, we use now [mux](https://github.com/gorilla/mux) as HTTP router.
- Added deletion logic in the `repository` interface.
- Added `CORSLocalhostMiddleware` mux middleware to allow CORS.