### PR TITLE
Merge exceptions instead of swapping

### DIFF
--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -98,7 +98,7 @@
         },
         {
             "aggregation_key": "java.lang.Exception@789",
-            "total_count": 16,
+            "total_count": 10,
             "severity": "warning",
             "latest_errors": [
                 {

--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -98,7 +98,7 @@
         },
         {
             "aggregation_key": "java.lang.Exception@789",
-            "total_count": 11,
+            "total_count": 14,
             "severity": "warning",
             "latest_errors": [
                 {

--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -98,7 +98,7 @@
         },
         {
             "aggregation_key": "java.lang.Exception@789",
-            "total_count": 14,
+            "total_count": 16,
             "severity": "warning",
             "latest_errors": [
                 {

--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -98,7 +98,7 @@
         },
         {
             "aggregation_key": "java.lang.Exception@789",
-            "total_count": 10,
+            "total_count": 11,
             "severity": "warning",
             "latest_errors": [
                 {

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 )
 
+const serviceName = "test-service"
+
 func TestAddToResolved(t *testing.T) {
-	serviceName := "test-service"
 	er := &inMemoryRepository{}
 
 	// service has empty list of resolved errors
@@ -28,7 +29,6 @@ func TestAddToResolved(t *testing.T) {
 }
 
 func TestRemoveResolved(t *testing.T) {
-	serviceName := "test-service"
 	er := &inMemoryRepository{}
 
 	er.ResolvedErrors.Store(serviceName, map[string]bool{"test-error-0": true})
@@ -43,7 +43,6 @@ func TestRemoveResolved(t *testing.T) {
 }
 
 func TestSearchResolved(t *testing.T) {
-	serviceName := "test-service"
 	er := &inMemoryRepository{}
 	er.ResolvedErrors.Store(serviceName, map[string]bool{"test-error-0": true})
 
@@ -57,7 +56,6 @@ func TestSearchResolved(t *testing.T) {
 }
 
 func TestResolveErrorError(t *testing.T) {
-	serviceName := "test-service"
 	er := &inMemoryRepository{}
 	er.AggregatedError.Store(serviceName, []ErrorAggregate{
 		{AggregationKey: "test-error-0"},

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -11,7 +11,7 @@ func TestAddToResolved(t *testing.T) {
 	// service has empty list of resolved errors
 	er.addToResolved(serviceName, "test-error-0")
 	if value, ok := er.ResolvedErrors.Load(serviceName); ok {
-		value, _ := value.([]string)
+		value, _ := value.(map[string]bool)
 		if len(value) != 1 {
 			t.Errorf("Expected 1 element, Found %d", len(value))
 		}
@@ -20,9 +20,24 @@ func TestAddToResolved(t *testing.T) {
 	// service has a resolved error
 	er.addToResolved(serviceName, "test-error-1")
 	if value, ok := er.ResolvedErrors.Load(serviceName); ok {
-		value, _ := value.([]string)
+		value, _ := value.(map[string]bool)
 		if len(value) != 2 {
 			t.Errorf("Expected 2 element, Found %d", len(value))
+		}
+	}
+}
+
+func TestRemoveResolved(t *testing.T) {
+	serviceName := "test-service"
+	er := &inMemoryRepository{}
+
+	er.ResolvedErrors.Store(serviceName, map[string]bool{"test-error-0": true})
+	er.RemoveResolved(serviceName, "test-error-0")
+
+	if value, ok := er.ResolvedErrors.Load(serviceName); ok {
+		value, _ := value.(map[string]bool)
+		if len(value) != 0 {
+			t.Errorf("Expected 0 element, Found %d", len(value))
 		}
 	}
 }
@@ -30,7 +45,7 @@ func TestAddToResolved(t *testing.T) {
 func TestSearchResolved(t *testing.T) {
 	serviceName := "test-service"
 	er := &inMemoryRepository{}
-	er.ResolvedErrors.Store(serviceName, []string{"test-error-0"})
+	er.ResolvedErrors.Store(serviceName, map[string]bool{"test-error-0": true})
 
 	if !er.SearchResolved(serviceName, "test-error-0") {
 		t.Errorf("Error should be found in resolved errors")

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -4,6 +4,43 @@ import (
 	"testing"
 )
 
+func TestAddToResolved(t *testing.T) {
+	serviceName := "test-service"
+	er := &inMemoryRepository{}
+
+	// service has empty list of resolved errors
+	er.addToResolved(serviceName, "test-error-0")
+	if value, ok := er.ResolvedErrors.Load(serviceName); ok {
+		value, _ := value.([]string)
+		if len(value) != 1 {
+			t.Errorf("Expected 1 element, Found %d", len(value))
+		}
+	}
+
+	// service has a resolved error
+	er.addToResolved(serviceName, "test-error-1")
+	if value, ok := er.ResolvedErrors.Load(serviceName); ok {
+		value, _ := value.([]string)
+		if len(value) != 2 {
+			t.Errorf("Expected 2 element, Found %d", len(value))
+		}
+	}
+}
+
+func TestSearchResolved(t *testing.T) {
+	serviceName := "test-service"
+	er := &inMemoryRepository{}
+	er.ResolvedErrors.Store(serviceName, []string{"test-error-0"})
+
+	if !er.SearchResolved(serviceName, "test-error-0") {
+		t.Errorf("Error should be found in resolved errors")
+	}
+
+	if er.SearchResolved(serviceName, "test-error-1") {
+		t.Errorf("Error shouldn't be found in resolved errors")
+	}
+}
+
 func TestResolveErrorError(t *testing.T) {
 	serviceName := "test-service"
 	er := &inMemoryRepository{}

--- a/scraper/models.go
+++ b/scraper/models.go
@@ -4,6 +4,7 @@ import "time"
 
 type responsePayload struct {
 	ErrorAggregate []errorAggregate `json:"aggregated_errors"`
+	Instance       string           `json:"instance"`
 }
 
 type errorAggregate struct {

--- a/scraper/models.go
+++ b/scraper/models.go
@@ -4,7 +4,7 @@ import "time"
 
 type responsePayload struct {
 	ErrorAggregate []errorAggregate `json:"aggregated_errors"`
-	Instance       string           `json:"instance"`
+	Target         string           `json:"target"`
 }
 
 type errorAggregate struct {

--- a/scraper/processor.go
+++ b/scraper/processor.go
@@ -15,7 +15,7 @@ const httpClientTimeoutSeconds = 30
 
 type Request struct {
 	Target        string
-	ResultChannel chan<- []errorAggregate
+	ResultChannel chan<- responsePayload
 	WaitGroup     *sync.WaitGroup
 }
 
@@ -38,7 +38,7 @@ func worker(p Processor) {
 			if errorAggregates, err := p.fetcher(r.Target); err == nil {
 				r.ResultChannel <- errorAggregates
 			} else {
-				r.ResultChannel <- make([]errorAggregate, 0)
+				r.ResultChannel <- responsePayload{}
 			}
 			r.WaitGroup.Done()
 		}
@@ -57,29 +57,29 @@ func NewProcessor(numWorkers int) Processor {
 	}
 }
 
-type ErrorsFetcher func(string) ([]errorAggregate, error)
+type ErrorsFetcher func(string) (responsePayload, error)
 
 func defaultErrorsFetcher() ErrorsFetcher {
-	return func(target string) ([]errorAggregate, error) {
+	return func(target string) (responsePayload, error) {
 		body, err := fetch(target)
 		if err != nil {
 			metrics.ErrorCollector.ReportWithHTTPContext(err, &periskop.HTTPContext{
 				RequestMethod: "GET",
 				RequestURL:    target,
 			}, "scrapped-url-error")
-			return nil, err
+			return responsePayload{}, err
 		}
 
-		var responsePayload responsePayload
-		if err := json.Unmarshal(body, &responsePayload); err != nil {
+		var rp responsePayload
+		if err := json.Unmarshal(body, &rp); err != nil {
 			metrics.ErrorCollector.ReportWithHTTPContext(err, &periskop.HTTPContext{
 				RequestMethod: "GET",
 				RequestURL:    target,
 			})
-			return nil, err
+			return responsePayload{}, err
 		}
-
-		return responsePayload.ErrorAggregate, nil
+		rp.Instance = target
+		return rp, nil
 	}
 }
 

--- a/scraper/processor.go
+++ b/scraper/processor.go
@@ -78,7 +78,7 @@ func defaultErrorsFetcher() ErrorsFetcher {
 			})
 			return responsePayload{}, err
 		}
-		rp.Instance = target
+		rp.Target = target
 		return rp, nil
 	}
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -84,9 +84,9 @@ func (scraper Scraper) Scrape() {
 	}
 }
 
-func scrapeInstances(addresses []string, endpoint string, processor Processor) <-chan []errorAggregate {
+func scrapeInstances(addresses []string, endpoint string, processor Processor) <-chan responsePayload {
 	var wg sync.WaitGroup
-	out := make(chan []errorAggregate, len(addresses))
+	out := make(chan responsePayload, len(addresses))
 
 	wg.Add(len(addresses))
 	for _, address := range addresses {

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -19,6 +19,7 @@ func (ea errorAggregateMap) combine(rp responsePayload, es instanceErrorAggregat
 	for _, item := range rp.ErrorAggregate {
 		if existing, exists := ea[item.AggregationKey]; exists {
 			prevCount := es[rp.Target][item.AggregationKey]
+			// TODO: review if num errors is less than before
 			ea[item.AggregationKey] = errorAggregate{
 				TotalCount:     existing.TotalCount + (item.TotalCount - prevCount),
 				AggregationKey: existing.AggregationKey,

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -14,17 +14,17 @@ import (
 
 type errorAggregateMap map[string]errorAggregate
 
-func (errorAggregateMap errorAggregateMap) combine(aggregatedErrors []errorAggregate) {
-	for _, item := range aggregatedErrors {
-		if existing, exists := errorAggregateMap[item.AggregationKey]; exists {
-			errorAggregateMap[item.AggregationKey] = errorAggregate{
+func (ea errorAggregateMap) combine(rp responsePayload) {
+	for _, item := range rp.ErrorAggregate {
+		if existing, exists := ea[item.AggregationKey]; exists {
+			ea[item.AggregationKey] = errorAggregate{
 				TotalCount:     existing.TotalCount + item.TotalCount,
 				AggregationKey: existing.AggregationKey,
 				Severity:       item.Severity,
 				LatestErrors:   combine(existing.LatestErrors, item.LatestErrors),
 			}
 		} else {
-			errorAggregateMap[item.AggregationKey] = item
+			ea[item.AggregationKey] = item
 		}
 	}
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -12,40 +12,11 @@ import (
 	"github.com/soundcloud/periskop/servicediscovery"
 )
 
+// map error key -> errorAggregate
 type errorAggregateMap map[string]errorAggregate
-type instanceErrorAggregateMap map[string]map[string]int
 
-func (ea errorAggregateMap) combine(serviceName string, r *repository.ErrorsRepository,
-	rp responsePayload, es instanceErrorAggregateMap) {
-	for _, item := range rp.ErrorAggregate {
-		if existing, exists := ea[item.AggregationKey]; exists {
-			prevCount := es[rp.Target][item.AggregationKey]
-			// TODO: review if num errors is less than before
-			ea[item.AggregationKey] = errorAggregate{
-				TotalCount:     existing.TotalCount + (item.TotalCount - prevCount),
-				AggregationKey: existing.AggregationKey,
-				Severity:       item.Severity,
-				LatestErrors:   combine(existing.LatestErrors, item.LatestErrors),
-			}
-			es[rp.Target][item.AggregationKey] = item.TotalCount
-		} else {
-			ea[item.AggregationKey] = item
-			if _, exists := es[rp.Target]; !exists {
-				es[rp.Target] = make(map[string]int)
-			}
-			es[rp.Target][item.AggregationKey] = item.TotalCount
-		}
-		// If an error that was previously mark as resolved is scrapped again
-		// it's going to be added again to list of errors
-		(*r).RemoveResolved(serviceName, item.AggregationKey)
-	}
-}
-
-func combine(first []errorWithContext, second []errorWithContext) []errorWithContext {
-	combined := append(first, second...)
-	sort.Sort(errorOccurrences(combined))
-	return combined
-}
+// map target -> error key -> error total occurrences
+type targetErrorsCountMap map[string]map[string]int
 
 type Scraper struct {
 	Resolver      servicediscovery.Resolver
@@ -54,6 +25,7 @@ type Scraper struct {
 	processor     Processor
 }
 
+// NewScraper create a new scraper for a given service name
 func NewScraper(resolver servicediscovery.Resolver, r *repository.ErrorsRepository,
 	serviceConfig config.Service, processor Processor) Scraper {
 	return Scraper{
@@ -64,15 +36,47 @@ func NewScraper(resolver servicediscovery.Resolver, r *repository.ErrorsReposito
 	}
 }
 
-// Scrape stuff
+func (errorAggregates errorAggregateMap) combine(serviceName string, r *repository.ErrorsRepository,
+	rp responsePayload, targetErrorsCount targetErrorsCountMap) {
+	for _, item := range rp.ErrorAggregate {
+		if existing, exists := errorAggregates[item.AggregationKey]; exists {
+			prevCount := targetErrorsCount[rp.Target][item.AggregationKey]
+			errorAggregates[item.AggregationKey] = errorAggregate{
+				TotalCount:     existing.TotalCount + (item.TotalCount - prevCount),
+				AggregationKey: existing.AggregationKey,
+				Severity:       item.Severity,
+				LatestErrors:   combineLastErrors(existing.LatestErrors, item.LatestErrors),
+			}
+			targetErrorsCount[rp.Target][item.AggregationKey] = item.TotalCount
+		} else {
+			errorAggregates[item.AggregationKey] = item
+			if _, exists := targetErrorsCount[rp.Target]; !exists {
+				targetErrorsCount[rp.Target] = make(map[string]int)
+			}
+			targetErrorsCount[rp.Target][item.AggregationKey] = item.TotalCount
+		}
+		// If an error that was previously mark as resolved is scrapped again
+		// it's going to be added to list of errors
+		(*r).RemoveResolved(serviceName, item.AggregationKey)
+	}
+}
+
+func combineLastErrors(first []errorWithContext, second []errorWithContext) []errorWithContext {
+	combined := append(first, second...)
+	sort.Sort(errorOccurrences(combined))
+	return combined
+}
+
+// Scrape runs go routines scrapping the list of targets of this service,
+// processes the errors and stores them into the repository.
 func (scraper Scraper) Scrape() {
 	serviceConfig := scraper.ServiceConfig
 	resolutions := scraper.Resolver.Resolve()
 	var resolvedAddresses = servicediscovery.EmptyResolvedAddresses()
 	timer := time.NewTimer(scraper.ServiceConfig.Scraper.RefreshInterval)
 
-	var errorsSnapshot = make(instanceErrorAggregateMap)
-	var currentAggregatedErrorsMap = make(errorAggregateMap)
+	var targetErrorsCount = make(targetErrorsCountMap)
+	var errorAggregates = make(errorAggregateMap)
 	for {
 		select {
 		case newResult := <-resolutions:
@@ -84,12 +88,13 @@ func (scraper Scraper) Scrape() {
 			timer.Stop()
 			for responsePayload := range scrapeInstances(resolvedAddresses.Addresses, serviceConfig.Scraper.Endpoint,
 				scraper.processor) {
-				currentAggregatedErrorsMap.combine(serviceConfig.Name, scraper.Repository,
-					responsePayload, errorsSnapshot)
+				errorAggregates.combine(serviceConfig.Name, scraper.Repository,
+					responsePayload, targetErrorsCount)
 			}
-			store(serviceConfig.Name, scraper.Repository, currentAggregatedErrorsMap)
+			store(serviceConfig.Name, scraper.Repository, errorAggregates)
+
 			numInstances := len(resolvedAddresses.Addresses)
-			numErrors := len(currentAggregatedErrorsMap)
+			numErrors := len(errorAggregates)
 			metrics.InstancesScrapped.WithLabelValues(serviceConfig.Name).Set(float64(numInstances))
 			metrics.ErrorsScrapped.WithLabelValues(serviceConfig.Name).Add(float64(numErrors))
 			log.Printf("%s: scraped %d errors from %d instances", serviceConfig.Name, numErrors, numInstances)
@@ -121,9 +126,9 @@ func scrapeInstances(addresses []string, endpoint string, processor Processor) <
 	return out
 }
 
-func store(serviceName string, r *repository.ErrorsRepository, m errorAggregateMap) {
-	errors := make([]repository.ErrorAggregate, 0, len(m))
-	for _, value := range m {
+func store(serviceName string, r *repository.ErrorsRepository, errorAggregates errorAggregateMap) {
+	errors := make([]repository.ErrorAggregate, 0, len(errorAggregates))
+	for _, value := range errorAggregates {
 		if !(*r).SearchResolved(serviceName, value.AggregationKey) {
 			severity := severityWithFallback(value.Severity)
 			errors = append(errors, repository.ErrorAggregate{

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -140,7 +140,6 @@ func store(serviceName string, r *repository.ErrorsRepository, errorAggregates e
 			metrics.ErrorOccurrences.WithLabelValues(serviceName, severity,
 				value.AggregationKey).Set(float64(value.TotalCount))
 		}
-
 	}
 	(*r).StoreErrors(serviceName, errors)
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -18,20 +18,20 @@ type instanceErrorAggregateMap map[string]map[string]int
 func (ea errorAggregateMap) combine(rp responsePayload, es instanceErrorAggregateMap) {
 	for _, item := range rp.ErrorAggregate {
 		if existing, exists := ea[item.AggregationKey]; exists {
-			prevCount := es[rp.Instance][item.AggregationKey]
+			prevCount := es[rp.Target][item.AggregationKey]
 			ea[item.AggregationKey] = errorAggregate{
 				TotalCount:     existing.TotalCount + (item.TotalCount - prevCount),
 				AggregationKey: existing.AggregationKey,
 				Severity:       item.Severity,
 				LatestErrors:   combine(existing.LatestErrors, item.LatestErrors),
 			}
-			es[rp.Instance][item.AggregationKey] = item.TotalCount
+			es[rp.Target][item.AggregationKey] = item.TotalCount
 		} else {
 			ea[item.AggregationKey] = item
-			if _, exists := es[rp.Instance]; !exists {
-				es[rp.Instance] = make(map[string]int)
+			if _, exists := es[rp.Target]; !exists {
+				es[rp.Target] = make(map[string]int)
 			}
-			es[rp.Instance][item.AggregationKey] = item.TotalCount
+			es[rp.Target][item.AggregationKey] = item.TotalCount
 		}
 	}
 }

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -13,7 +13,7 @@ func TestCombineErrorsSortsByTimestamp(t *testing.T) {
 	var firstResponsePayload responsePayload
 	var secondResponsePayload responsePayload
 
-	json.Unmarshal(firstContent, &firstResponsePayload)  // nolint[errcheck]
+	json.Unmarshal(firstContent, &firstResponsePayload)   // nolint[errcheck]
 	json.Unmarshal(secondContent, &secondResponsePayload) // nolint[errcheck]
 
 	firstOccurrences := firstResponsePayload.ErrorAggregate[0].LatestErrors

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCombineErrorsSortsByTimestamp(t *testing.T) {
+func TestCombineLastErrorsSortsByTimestamp(t *testing.T) {
 	firstContent, _ := ioutil.ReadFile("sample-response1.json")
 	secondContent, _ := ioutil.ReadFile("sample-response2.json")
 
@@ -19,7 +19,7 @@ func TestCombineErrorsSortsByTimestamp(t *testing.T) {
 	firstOccurrences := firstResponsePayload.ErrorAggregate[0].LatestErrors
 	secondOccurrences := secondResponsePayload.ErrorAggregate[0].LatestErrors
 
-	result := combine(firstOccurrences, secondOccurrences)
+	result := combineLastErrors(firstOccurrences, secondOccurrences)
 
 	expectedUUIDs := []string{"uuid4", "uuid2", "uuid3", "uuid1"}
 


### PR DESCRIPTION
- Changed method to combine errors. Now we compute the total of errors counting the errors per target (instances of a given service). This allows us to have historical data of errors that are already fix after a deploy.
- `Target` added to `ResponsePayload`, need to aggreggate errors per target.
- Added a hash map to track resolved errors.
- When an error is mark as _resolved_, we still add to list of errors if the error is scraped in the next cycle. 
- Minor refactors and added some comented some functions.

This PR solves #128 