### PR TITLE
Support Redux DevTools

### DIFF
--- a/web/src/data/errors.ts
+++ b/web/src/data/errors.ts
@@ -89,7 +89,6 @@ const initialState: ErrorsState = {
 }
 
 function errorsReducer(state = initialState, action: ErrorsAction) {
-  console.log(action)
   switch (action.type) {
     case FETCH:
       return {

--- a/web/src/data/store.ts
+++ b/web/src/data/store.ts
@@ -10,9 +10,11 @@ function configureStore() {
 
   const rootReducer = () => ({});
 
+  // @ts-ignore
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   return createStore(
     rootReducer,
-    compose(applyMiddleware(...middlewares))
+    composeEnhancers(applyMiddleware(...middlewares))
   );
 }
 


### PR DESCRIPTION
This removes the logging of actions in favor of the Redux DevTools. The browser extension is supported in Chrome and Firefox and it allows us to debug issues with the store and reducers with much more flexibility (see screenshots)

<img width="1440" alt="Screen Shot 2020-11-23 at 17 19 25" src="https://user-images.githubusercontent.com/1178516/99987065-4e889500-2db0-11eb-93fb-df90873d8993.png">
<img width="1440" alt="Screen Shot 2020-11-23 at 17 19 32" src="https://user-images.githubusercontent.com/1178516/99987071-521c1c00-2db0-11eb-82b4-adb001c8ad34.png">
