### PR TITLE
Bump the number of occurrences per error in the API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,7 +23,7 @@ func NewServicesListHandler(r *repository.ErrorsRepository) http.Handler {
 func NewErrorsListHandler(r *repository.ErrorsRepository) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		vars := mux.Vars(req)
-		numberOfOccurrencesPerError := 10
+		numberOfOccurrencesPerError := 100
 
 		if service, found := vars["service_name"]; found {
 			err := errorsForService(w, r, service, numberOfOccurrencesPerError)


### PR DESCRIPTION
  - 10 is very limited for debugging
  - More errors are stored anyway, so we can return more to the UI. 100
    should not be a problem.
  - In the future, this could be parameterized and changed in the UI