### PR TITLE
Upgrade to go1.16

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ task:
 task:
   name: Build Api
   container:
-    image: golang:latest
+    image: golang:1.16
   env:
     GOPROXY: https://proxy.golang.org
   modules_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 ## Build api
-FROM golang:1.14.1 AS api-builder
+FROM golang:1.16 AS api-builder
 
 WORKDIR /periskop
-
-ENV GO111MODULE=on
 
 COPY go.mod .
 COPY go.sum .

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ build-web:
 	npm run build:dist --prefix $(WEB_FOLDER)
 
 run-api:
-	GO111MODULE=on go build -o periskop && ./periskop -port=$(PORT) -config ./config.dev.yaml
+	go build -o periskop && ./periskop -port=$(PORT) -config ./config.dev.yaml
 
 run-mock-target:
-	GO111MODULE=on go build -o mock-target mocktarget/mocktarget.go && ./mock-target
+	go build -o mock-target mocktarget/mocktarget.go && ./mock-target
 
 run-web:
 	npm start --prefix $(WEB_FOLDER)
@@ -27,10 +27,10 @@ run-web:
 run: build-web run-api
 
 build-api:
-	GO111MODULE=on go build ./...
+	go build ./...
 
 test-api:
-	GO111MODULE=on go test ./...
+	go test ./...
 
 lint-api:
 	golangci-lint run


### PR DESCRIPTION
We no longer need to set GO111MODULE for the latest go version,
it defaults to always using Go modules.

See https://blog.golang.org/go116-module-changes