### PR TITLE
Fix panic when reused target ids result in negative counters

### DIFF
--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -62,7 +62,12 @@ func (errorAggregates errorAggregateMap) combine(serviceName string, r *reposito
 				}
 			} else {
 				errorCountDelta = 0
-				log.Printf("warning: count of errors for '%s' target is inconsistent: prev %d, current %d.\nCounters won't be updated \n", rp.Target, prevCount, item.TotalCount)
+				log.Printf("warning: count of errors for '%s' target is inconsistent: prev %d, current %d.",
+					rp.Target,
+					prevCount,
+					item.TotalCount,
+				)
+				log.Printf(" Counters won't be updated\n")
 			}
 		} else {
 			errorCountDelta = item.TotalCount

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -64,7 +64,6 @@ func (errorAggregates errorAggregateMap) combine(serviceName string, r *reposito
 					serviceName, r, rp,
 					targetErrorsCount, errorInstancesAccumulator)
 			} else {
-				errorCountDelta = 0
 				log.Printf("warning: count of errors for '%s' target is inconsistent: prev %d, current %d.",
 					rp.Target,
 					prevCount,
@@ -73,7 +72,6 @@ func (errorAggregates errorAggregateMap) combine(serviceName string, r *reposito
 				log.Printf(" Counters won't be updated\n")
 			}
 		} else {
-			errorCountDelta = item.TotalCount
 			errorAggregates[item.AggregationKey] = item
 			updateValues(item, item.TotalCount, lastestErrors,
 				serviceName, r, rp,

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -83,7 +83,6 @@ func (errorAggregates errorAggregateMap) combine(serviceName string, r *reposito
 func updateValues(item errorAggregate, errorCountDelta int, latestErrors []errorWithContext,
 	serviceName string, r *repository.ErrorsRepository, rp responsePayload,
 	targetErrorsCount targetErrorsCountMap, errorInstancesAccumulator errorInstancesAccumulatorMap) {
-
 	metrics.ErrorOccurrences.WithLabelValues(serviceName, item.Severity, rp.Target,
 		item.AggregationKey).Add(float64(errorCountDelta))
 	targetErrorsCount[rp.Target][item.AggregationKey] = item.TotalCount

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"testing"
+
+	"github.com/soundcloud/periskop/repository"
 )
 
 func TestCombineLastErrorsSortsByTimestamp(t *testing.T) {
@@ -27,5 +29,69 @@ func TestCombineLastErrorsSortsByTimestamp(t *testing.T) {
 		if element.UUID != expectedUUIDs[i] {
 			t.Errorf("Expected %s, Found %s", expectedUUIDs[i], element.UUID)
 		}
+	}
+}
+
+func TestScrapeCombine(t *testing.T) {
+	var targetErrorsCount = make(targetErrorsCountMap)
+	var errorAggregates = make(errorAggregateMap)
+	errorInstancesAccumulator := make(errorInstancesAccumulatorMap)
+	repo := repository.NewInMemory()
+
+	firstContent, _ := ioutil.ReadFile("sample-response1.json")
+	var rp responsePayload
+	json.Unmarshal(firstContent, &rp) // nolint[errcheck]
+	rp.Target = "test"
+
+	errorAggregates.combine("test", &repo, rp, targetErrorsCount, errorInstancesAccumulator)
+
+	count := targetErrorsCount["test"]["com.soundcloud.Foon@e28e036e"]
+	if count != 2 {
+		t.Errorf("Expected 2 element, Found %d", count)
+	}
+
+	countErrorInstances := len(errorInstancesAccumulator["com.soundcloud.Foon@e28e036e"])
+	if countErrorInstances != 2 {
+		t.Errorf("Expected 2 element, Found %d", countErrorInstances)
+	}
+
+	rp.ErrorAggregate[0].TotalCount = 4
+	errorAggregates.combine("test", &repo, rp, targetErrorsCount, errorInstancesAccumulator)
+
+	count = targetErrorsCount["test"]["com.soundcloud.Foon@e28e036e"]
+	if count != 4 {
+		t.Errorf("Expected 4 element, Found %d", count)
+	}
+
+	countErrorInstances = len(errorInstancesAccumulator["com.soundcloud.Foon@e28e036e"])
+	if countErrorInstances != 4 {
+		t.Errorf("Expected 2 element, Found %d", countErrorInstances)
+	}
+}
+
+func TestScapeCombineNotUpdate(t *testing.T) {
+	var targetErrorsCount = make(targetErrorsCountMap)
+	var errorAggregates = make(errorAggregateMap)
+	errorInstancesAccumulator := make(errorInstancesAccumulatorMap)
+	repo := repository.NewInMemory()
+
+	firstContent, _ := ioutil.ReadFile("sample-response1.json")
+	var rp responsePayload
+	json.Unmarshal(firstContent, &rp) // nolint[errcheck]
+	rp.Target = "test"
+
+	errorAggregates.combine("test", &repo, rp, targetErrorsCount, errorInstancesAccumulator)
+
+	rp.ErrorAggregate[0].TotalCount = 1
+	errorAggregates.combine("test", &repo, rp, targetErrorsCount, errorInstancesAccumulator)
+
+	count := targetErrorsCount["test"]["com.soundcloud.Foon@e28e036e"]
+	if count != 2 {
+		t.Errorf("Expected 2 element, Found %d", count)
+	}
+
+	countErrorInstances := len(errorInstancesAccumulator["com.soundcloud.Foon@e28e036e"])
+	if countErrorInstances != 2 {
+		t.Errorf("Expected 2 element, Found %d", countErrorInstances)
 	}
 }


### PR DESCRIPTION
  - The current implementation assumes that target identifiers are never
    reused. This is not the case when using dns, static files and other
    forms of service discovery.
  - The logic to keep counters accurate even when targets go away
    (persistent state after deploys) does not handle this well and might
    result in negative deltas for updating counts.
  - This mitigation prevents the panic by ignoring negative deltas
    (which results in non updated counts for reused recycled targets)
    and adds a warning to notify this problem.
  - A long term solution has been discussed and will be implemented soon
    (it involves changes in clients and schemas to incorporate a unique
    identifier per target).

TODO:

  - [ ] add tests

Mitigates #169 

Co-Authored-By: Marc Tuduri <marc.tuduri@soundcloud.com>
