### PR TITLE
Expose scraped targets via API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,6 +20,15 @@ func NewServicesListHandler(r *repository.ErrorsRepository) http.Handler {
 	})
 }
 
+func NewTargetsHandler(r *repository.ErrorsRepository) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := targets(w, r)
+		if err != nil {
+			metrics.ErrorCollector.ReportWithHTTPRequest(err, req)
+		}
+	})
+}
+
 func NewErrorsListHandler(r *repository.ErrorsRepository) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		vars := mux.Vars(req)
@@ -81,6 +90,10 @@ func errorsForService(w http.ResponseWriter, r *repository.ErrorsRepository,
 
 func servicesList(w http.ResponseWriter, r *repository.ErrorsRepository) error {
 	return renderJSON(w, (*r).GetServices())
+}
+
+func targets(w http.ResponseWriter, r *repository.ErrorsRepository) error {
+	return renderJSON(w, (*r).GetTargets())
 }
 
 func renderJSON(w http.ResponseWriter, value interface{}) error {

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -72,3 +72,17 @@ func TestResolveErrorError(t *testing.T) {
 		}
 	}
 }
+
+func TestSetAndRetrieveTargets(t *testing.T) {
+	er := &inMemoryRepository{}
+	er.StoreTargets(serviceName, []Target{
+		{Endpoint: "localhost:3000/"},
+		{Endpoint: "localhost:3001/"},
+	})
+
+	retrievedTargets := er.GetTargets()
+	if retrievedTargets[serviceName][0].Endpoint != "localhost:3000/" ||
+		retrievedTargets[serviceName][1].Endpoint != "localhost:3001/" {
+		t.Errorf("Inconsistent target fetch and retrieval")
+	}
+}

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -94,6 +94,7 @@ func (scraper Scraper) Scrape() {
 		select {
 		case newResult := <-resolutions:
 			resolvedAddresses = newResult
+			storeTargets(serviceConfig.Name, scraper.Repository, resolvedAddresses)
 			log.Printf("Received new dns resolution result for %s. Address resolved: %d\n", serviceConfig.Name,
 				len(resolvedAddresses.Addresses))
 
@@ -105,7 +106,7 @@ func (scraper Scraper) Scrape() {
 				errorAggregates.combine(serviceConfig.Name, scraper.Repository,
 					responsePayload, targetErrorsCount, errorInstancesAccumulator)
 			}
-			store(serviceConfig.Name, scraper.Repository, errorAggregates)
+			storeErrors(serviceConfig.Name, scraper.Repository, errorAggregates)
 
 			numInstances := len(resolvedAddresses.Addresses)
 			numErrors := len(errorAggregates)
@@ -140,7 +141,7 @@ func scrapeInstances(addresses []string, endpoint string, processor Processor) <
 	return out
 }
 
-func store(serviceName string, r *repository.ErrorsRepository, errorAggregates errorAggregateMap) {
+func storeErrors(serviceName string, r *repository.ErrorsRepository, errorAggregates errorAggregateMap) {
 	errors := make([]repository.ErrorAggregate, 0, len(errorAggregates))
 	for _, value := range errorAggregates {
 		if !(*r).SearchResolved(serviceName, value.AggregationKey) {
@@ -155,6 +156,16 @@ func store(serviceName string, r *repository.ErrorsRepository, errorAggregates e
 		}
 	}
 	(*r).StoreErrors(serviceName, errors)
+}
+
+func storeTargets(serviceName string, r *repository.ErrorsRepository, addr servicediscovery.ResolvedAddresses) {
+	targets := make([]repository.Target, 0, len(addr.Addresses))
+	for _, value := range addr.Addresses {
+		targets = append(targets, repository.Target{
+			Endpoint: value,
+		})
+	}
+	(*r).StoreTargets(serviceName, targets)
 }
 
 func toRepositoryErrorsWithContent(occurrences []errorWithContext) []repository.ErrorWithContext {


### PR DESCRIPTION
  - This allows verifying integrations and debugging
  - In future iterations it will be added to the UI

Example:

```
➜  curl localhost:7777/targets/ | jq
{
  "mock-target": [
    {
      "endpoint": "127.0.0.1:7778"
    }
  ],
  "periskop": [
    {
      "endpoint": "localhost:7777"
    }
  ]
}
```

TODO:
  - [x] Add tests 


Addresses #172 