### PR TITLE
Improve UI for info messages

### DIFF
--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -120,6 +120,26 @@
                     }
                 }
             ]
+        },
+        {
+            "aggregation_key": "info-message",
+            "total_count": 1,
+            "severity": "info",
+            "created_at": "2019-09-15T11:46:25.333Z",
+            "latest_errors": [
+                {
+                    "error": {
+                        "message": "Something not so bad"
+                    },
+                    "uuid": "e81e56ff-7f65-4279-1234-dd6075777777",
+                    "timestamp": "2019-09-15T11:46:25.333Z",
+                    "severity": "info",
+                    "http_context": {
+                        "request_method": "GET",
+                        "request_url": "http://notsobadrequest.org/third-endpoint"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -40,10 +40,7 @@ const ErrorComponent: React.FC<Props> = (props) => {
 
     return (
       <div>      
-        <ListGroup.Item>
-          <h4 className="list-group-item-heading"> Class</h4>
-          { errorInstance.class }
-        </ListGroup.Item>
+        { renderClass(errorInstance.class) }
         { renderMessage(errorInstance.message) }
         { renderStackTrace(errorInstance.stacktrace) }
         { renderCause(errorInstance.cause) }
@@ -93,6 +90,19 @@ const ErrorComponent: React.FC<Props> = (props) => {
       <ListGroup.Item>
         <h4 className="list-group-item-heading"> Cause</h4>
         { renderErrorInstance(cause) }
+      </ListGroup.Item>
+    )
+  }
+
+  const renderClass = (klass: string) => {
+    if (klass === null || klass.trim().length === 0) {
+      return ""
+    }
+
+    return (
+      <ListGroup.Item>
+        <h4 className="list-group-item-heading"> Class</h4>
+        { klass }
       </ListGroup.Item>
     )
   }


### PR DESCRIPTION
  - In addition to reporting errors, it can be useful to use periskop to
    report events of interest that are not necessarily errors. Combined
    with the sampling capabilities of periskop and the HTTP context, it
    can be useful to debug rare events and a better alternative to
    grepping through logs.
  - This change demonstrates the usage of info messages and improves the
    UI to hide missing optional fields like 'class'.
  - Changes in client libraries will follow to facilitate creating these
    kinds of info messages directly from code.