### PR TITLE
Add target_uuid to schema definition

### DIFF
--- a/mocktarget/errors.json
+++ b/mocktarget/errors.json
@@ -1,4 +1,5 @@
 {
+    "target_uuid": "8589E8C9-86B6-4B50-B70E-8ABFA4B588A3",
     "aggregated_errors": [
         {
             "aggregation_key": "java.lang.Run/ timeException@123", 

--- a/representation/errors.proto
+++ b/representation/errors.proto
@@ -3,6 +3,7 @@ package com.soundcloud.periskop;
 
 message Errors {
     repeated AggregatedError aggregatedErrors = 1;
+    string target_uuid = 2; // Must be unique per exception collector instance
 }
 
 message AggregatedError {

--- a/scraper/models.go
+++ b/scraper/models.go
@@ -4,7 +4,7 @@ import "time"
 
 type responsePayload struct {
 	ErrorAggregate []errorAggregate `json:"aggregated_errors"`
-	Target         string           `json:"target"`
+	Target         string           `json:"target_uuid"`
 }
 
 type errorAggregate struct {

--- a/scraper/processor.go
+++ b/scraper/processor.go
@@ -78,7 +78,12 @@ func defaultErrorsFetcher() ErrorsFetcher {
 			})
 			return responsePayload{}, err
 		}
-		rp.Target = target
+
+		// Fallback to target if no target_uuid is present for backward compatibility
+		// Can lead to issues with counters as it is not guaranteed to be unique
+		if len(rp.Target) == 0 {
+			rp.Target = target
+		}
 		return rp, nil
 	}
 }


### PR DESCRIPTION
  - Dealing with persistent counters that are correct as instances come
    and go requires unique identifiers to avoid either double counting
    or decreasing counters when a new instance replaces an old using
    the same target and reports different numbers of exceptions.
  - The old implementation assumed that targets are unique but that's
    not the case for many forms of service discovery.
  - #171 mitigated this problem by did not solve it, it just prevented a
    panic at the cost of counters that are potentially incorrect.
  - As a long term solution, client libraries must generate and include
    a UUID in exception responses.
  - For backard compatibility, the target_uuid is optional but its use
    is highly encouraged.