### PR TITLE
Fix issue with First Occurrence

### DIFF
--- a/scraper/sample-response2.json
+++ b/scraper/sample-response2.json
@@ -36,7 +36,7 @@
                         "cause": null
                     },
                     "uuid": "uuid4",
-                    "timestamp": "2018-09-13T15:26:30.630Z",
+                    "timestamp": "2018-09-13T16:26:30.630Z",
                     "severity": "error",
                     "http_context": {
                         "request_method": "GET",

--- a/scraper/sample-response2.json
+++ b/scraper/sample-response2.json
@@ -4,7 +4,7 @@
             "aggregation_key": "com.soundcloud.Foon@e28e036e",
             "total_count": 2,
             "severity": "error",
-            "created_at": "2018-09-13T16:23:30.630Z",
+            "created_at": "2018-09-13T15:23:30.630Z",
             "latest_errors": [
                 {
                     "error": {
@@ -36,7 +36,7 @@
                         "cause": null
                     },
                     "uuid": "uuid4",
-                    "timestamp": "2018-09-13T16:26:30.630Z",
+                    "timestamp": "2018-09-13T15:26:30.630Z",
                     "severity": "error",
                     "http_context": {
                         "request_method": "GET",

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -52,7 +52,7 @@ func (errorAggregates errorAggregateMap) combine(serviceName string, r *reposito
 		if existing, exists := errorAggregates[item.AggregationKey]; exists {
 			prevCount := targetErrorsCount[rp.Target][item.AggregationKey]
 			if prevCount <= item.TotalCount {
-				// Set the CreatedAt of the aggregated error the oldest occurrence of it
+				// Set the CreatedAt of its oldest occurrence
 				createdAt := existing.CreatedAt
 				if item.CreatedAt.Before(createdAt) {
 					createdAt = item.CreatedAt

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -52,13 +52,19 @@ func (errorAggregates errorAggregateMap) combine(serviceName string, r *reposito
 		if existing, exists := errorAggregates[item.AggregationKey]; exists {
 			prevCount := targetErrorsCount[rp.Target][item.AggregationKey]
 			if prevCount <= item.TotalCount {
+				// Set the CreatedAt of the aggregated error the oldest occurrence of it
+				createdAt := existing.CreatedAt
+				if item.CreatedAt.Before(createdAt) {
+					createdAt = item.CreatedAt
+				}
+
 				errorCountDelta = item.TotalCount - prevCount
 				errorAggregates[item.AggregationKey] = errorAggregate{
 					TotalCount:     existing.TotalCount + errorCountDelta,
 					AggregationKey: existing.AggregationKey,
 					Severity:       item.Severity,
 					LatestErrors:   lastestErrors,
-					CreatedAt:      existing.CreatedAt,
+					CreatedAt:      createdAt,
 				}
 				updateValues(item, errorCountDelta, lastestErrors,
 					serviceName, r, rp,

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -95,3 +95,27 @@ func TestScapeCombineNotUpdate(t *testing.T) {
 		t.Errorf("Expected 2 element, Found %d", countErrorInstances)
 	}
 }
+
+func TestScapeCombineCreatedAt(t *testing.T) {
+	var targetErrorsCount = make(targetErrorsCountMap)
+	var errorAggregates = make(errorAggregateMap)
+	errorInstancesAccumulator := make(errorInstancesAccumulatorMap)
+	repo := repository.NewInMemory()
+
+	firstContent, _ := ioutil.ReadFile("sample-response1.json")
+	var rp responsePayload
+	json.Unmarshal(firstContent, &rp) // nolint[errcheck]
+	rp.Target = "test1"
+	errorAggregates.combine("test1", &repo, rp, targetErrorsCount, errorInstancesAccumulator)
+
+	secondContent, _ := ioutil.ReadFile("sample-response2.json")
+	json.Unmarshal(secondContent, &rp) // nolint[errcheck]
+	rp.Target = "test2"
+	errorAggregates.combine("test2", &repo, rp, targetErrorsCount, errorInstancesAccumulator)
+
+	createdAtHour := errorAggregates["com.soundcloud.Foon@e28e036e"].CreatedAt.Hour()
+
+	if createdAtHour != 15 {
+		t.Errorf("Expected 15h, Found %d", createdAtHour)
+	}
+}


### PR DESCRIPTION
This fixes an issue where sometimes the `First Occurrence` of an error was more recent than the last error of `Latest Occurrences`. Now we always keep the oldest value of the scrapped targets.