### PR TITLE
Improve writes performance

### DIFF
--- a/repository/orm.go
+++ b/repository/orm.go
@@ -64,7 +64,6 @@ func (r *ormRepository) GetErrors(serviceName string, numberOfErrors int) ([]Err
 
 // ReplaceErrors deletes previous stored errors for a service name and stores the new list of errors in json format
 func (r *ormRepository) ReplaceErrors(serviceName string, errors []ErrorAggregate) {
-
 	for _, errorAggregate := range errors {
 		errObj := AggregatedError{}
 		key := errorAggregate.AggregationKey
@@ -87,7 +86,6 @@ func (r *ormRepository) ReplaceErrors(serviceName string, errors []ErrorAggregat
 				Update("Errors", errorAggregate)
 		}
 	}
-
 }
 
 // GetServices fetches the list of unique services

--- a/repository/orm.go
+++ b/repository/orm.go
@@ -28,6 +28,7 @@ type AggregatedError struct {
 	ServiceName    string `gorm:"index"`
 	AggregationKey string `gorm:"index"`
 	Errors         ErrorAggregate
+	TotalCount     int
 }
 
 func NewORMRepository(db *gorm.DB) ErrorsRepository {
@@ -63,30 +64,30 @@ func (r *ormRepository) GetErrors(serviceName string, numberOfErrors int) ([]Err
 
 // ReplaceErrors deletes previous stored errors for a service name and stores the new list of errors in json format
 func (r *ormRepository) ReplaceErrors(serviceName string, errors []ErrorAggregate) {
-	err := r.DB.Transaction(func(tx *gorm.DB) error {
-		// Delete previous records
-		if err := tx.
-			Where("service_name = ?", serviceName).
-			Unscoped().
-			Delete(&AggregatedError{}).Error; err != nil {
-			return err
-		}
 
-		for _, errorAggregate := range errors {
-			if err := tx.
-				Create(&AggregatedError{
-					ServiceName:    serviceName,
-					Errors:         errorAggregate,
-					AggregationKey: errorAggregate.AggregationKey,
-				}).Error; err != nil {
-				return err
-			}
+	for _, errorAggregate := range errors {
+		errObj := AggregatedError{}
+		key := errorAggregate.AggregationKey
+		result := r.DB.Model(&AggregatedError{}).
+			Where("service_name = ?", serviceName).
+			Where("aggregation_key = ?", key).
+			First(&errObj)
+		if result.RowsAffected == 0 {
+			r.DB.Create(&AggregatedError{
+				ServiceName:    serviceName,
+				Errors:         errorAggregate,
+				AggregationKey: key,
+				TotalCount:     errorAggregate.TotalCount,
+			})
+		} else if errorAggregate.TotalCount > errObj.TotalCount { // only update if there are more errors than before
+			r.DB.Model(&AggregatedError{}).
+				Where("service_name = ?", serviceName).
+				Where("aggregation_key = ?", key).
+				Update("total_count", errorAggregate.TotalCount).
+				Update("Errors", errorAggregate)
 		}
-		return nil
-	})
-	if err != nil {
-		metrics.ErrorCollector.Report(err)
 	}
+
 }
 
 // GetServices fetches the list of unique services

--- a/repository/orm.go
+++ b/repository/orm.go
@@ -83,7 +83,7 @@ func (r *ormRepository) ReplaceErrors(serviceName string, errors []ErrorAggregat
 				Where("service_name = ?", serviceName).
 				Where("aggregation_key = ?", key).
 				Update("total_count", errorAggregate.TotalCount).
-				Update("Errors", errorAggregate)
+				Update("errors", errorAggregate)
 		}
 	}
 }

--- a/repository/orm_test.go
+++ b/repository/orm_test.go
@@ -26,11 +26,16 @@ func newSQLiteMemory() *gorm.DB {
 func TestORMReplaceErrors(t *testing.T) {
 	db := newSQLiteMemory()
 	r := NewORMRepository(db)
+	key := "errorKey"
+	serviceName := "test_replace"
+
+	// test if creation is successful
 	errors := []ErrorAggregate{
 		{
-			AggregationKey: "key",
+			AggregationKey: key,
 			Severity:       "error",
 			CreatedAt:      time.Unix(0, 0).Unix(),
+			TotalCount:     1,
 			LatestErrors: []ErrorWithContext{
 				{
 					Error:     ErrorInstance{},
@@ -39,10 +44,38 @@ func TestORMReplaceErrors(t *testing.T) {
 				},
 			},
 		}}
-	r.ReplaceErrors("test_store", errors)
-	r.ReplaceErrors("test_store", errors)
-	if countErrors(db, "test_store") != 1 {
-		t.Errorf("Found %d errors, expected 1", countErrors(db, "test_store"))
+	r.ReplaceErrors(serviceName, errors)
+	if countErrors(db, serviceName) != 1 {
+		t.Errorf("Found %d errors, expected 1", countErrors(db, serviceName))
+	}
+
+	// test if update is successful
+	errors = []ErrorAggregate{
+		{
+			AggregationKey: key,
+			Severity:       "error",
+			CreatedAt:      time.Unix(0, 0).Unix(),
+			TotalCount:     2,
+			LatestErrors: []ErrorWithContext{
+				{
+					Error:     ErrorInstance{},
+					Severity:  "error",
+					Timestamp: time.Unix(0, 0).Unix(),
+				},
+			},
+		}}
+	r.ReplaceErrors(serviceName, errors)
+	if countErrors(db, serviceName) != 1 {
+		t.Errorf("Found %d errors, expected 1", countErrors(db, serviceName))
+	}
+
+	errObj := AggregatedError{}
+	db.Model(&AggregatedError{}).
+		Where("service_name = ?", serviceName).
+		Where("aggregation_key = ?", key).
+		First(&errObj)
+	if errObj.TotalCount != 2 {
+		t.Errorf("Found %d error instances, expected 2", errObj.TotalCount)
 	}
 }
 

--- a/repository/orm_test.go
+++ b/repository/orm_test.go
@@ -53,7 +53,7 @@ func TestORMReplaceErrors(t *testing.T) {
 	errors = []ErrorAggregate{
 		{
 			AggregationKey: key,
-			Severity:       "error",
+			Severity:       "warning",
 			CreatedAt:      time.Unix(0, 0).Unix(),
 			TotalCount:     2,
 			LatestErrors: []ErrorWithContext{
@@ -76,6 +76,9 @@ func TestORMReplaceErrors(t *testing.T) {
 		First(&errObj)
 	if errObj.TotalCount != 2 {
 		t.Errorf("Found %d error instances, expected 2", errObj.TotalCount)
+	}
+	if errObj.Errors.Severity != "warning" {
+		t.Errorf("Wrong data from Errors Severity field, found '%s', expected 'warning'", errObj.Errors.Severity)
 	}
 }
 


### PR DESCRIPTION
* Previous implementation of database storage was deleting all the errors and storing them again. That causes a database lock which makes that everything goes slower.
* Now  the error list of an aggregated error is updated if the number of errors increases. 