### PR TITLE
Improve response body rendering

### DIFF
--- a/web/src/components/Error.tsx
+++ b/web/src/components/Error.tsx
@@ -169,7 +169,7 @@ const ErrorComponent: React.FC<Props> = (props) => {
     return(
       <ListGroup.Item>
         <h4 className="list-group-item-heading"> Body</h4>
-        {request_body}
+        <pre className="request-body">{request_body}</pre>
       </ListGroup.Item>
     );
   };

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -67,3 +67,8 @@ th {
 table {
   table-layout: fixed;
 }
+
+.request-body {
+  max-height: initial;
+}
+


### PR DESCRIPTION
By using a `pre` tag the rendering of the request data can be improved, going from a block of consecutive data into easier to read blocks.

Note: by default Bootstrap will constraint `pre` tags to a maximum height of 400px, so I added a new style to prevent that from happening here.