### PR TITLE
Updated code to use the latest periskop-go API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/periskop-dev/periskop
 require (
 	github.com/go-kit/kit v0.10.0
 	github.com/gorilla/mux v1.7.4
+	github.com/periskop-dev/periskop-go v0.0.0-20220512172842-c5603b259677
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1
 	gopkg.in/yaml.v2 v2.2.8
@@ -72,7 +73,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	github.com/periskop-dev/periskop-go v0.0.0-20220106155054-4dd58584af9f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChl
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
-github.com/periskop-dev/periskop-go v0.0.0-20220106155054-4dd58584af9f h1:481V7/bVRnfFNFtLphPKuw7X63pTRUzPzeD9iGG5tw8=
-github.com/periskop-dev/periskop-go v0.0.0-20220106155054-4dd58584af9f/go.mod h1:EUNa+ioN6++5iJcixQUY9eGTzUGjhkZALQTcNejW5vg=
+github.com/periskop-dev/periskop-go v0.0.0-20220512172842-c5603b259677 h1:ze38eGrVZIVbIwV1iXib/lm26uB0FDBnSjppGqKZUfQ=
+github.com/periskop-dev/periskop-go v0.0.0-20220512172842-c5603b259677/go.mod h1:EUNa+ioN6++5iJcixQUY9eGTzUGjhkZALQTcNejW5vg=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
@@ -931,7 +931,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/scraper/processor.go
+++ b/scraper/processor.go
@@ -63,10 +63,14 @@ func defaultErrorsFetcher() ErrorsFetcher {
 	return func(target string) (responsePayload, error) {
 		body, err := fetch(target)
 		if err != nil {
-			metrics.ErrorCollector.ReportWithHTTPContext(err, &periskop.HTTPContext{
-				RequestMethod: "GET",
-				RequestURL:    target,
-			}, "scrapped-url-error")
+			metrics.ErrorCollector.Report(periskop.ErrorReport{
+				Err: err,
+				HTTPCtx: &periskop.HTTPContext{
+					RequestMethod: "GET",
+					RequestURL:    target,
+				},
+				ErrKey: "scrapped-url-error",
+			})
 			return responsePayload{}, err
 		}
 


### PR DESCRIPTION
This is a followup to https://github.com/periskop-dev/periskop-go/pull/13.